### PR TITLE
remove draft & centered contact button

### DIFF
--- a/templates/conduct.html
+++ b/templates/conduct.html
@@ -5,208 +5,162 @@
 {% endblock title %}
 
 {% block content %}
-  <div class="main-content">
-      <div class="main-header">
-        <div class="main-header__text blue-background">
-          <h1>Techtonica Mission and Code of Conduct</h1>
-          <p>Last modified: 11 September 2016</p>
-        </div>
-      </div>
-      <div class="row row__center mission" id="mission">
-        <div class="column">
-          <h1 class="blue-h1">Mission</h1>
-          <p class="justify">Techtonica’s mission is to make every engineering team as diverse as its local community while empowering low-income women and non-binary adults through tech training and careers.</p>
-        </div>
-      </div>
-      <div class="row row__center blue-background short-form-conduct" id="shortformconduct">
-        <div class="column">
-          <h1>Short Form Code of Conduct</h1>
-          <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form and we prioritize marginalized people’s safety over privileged people’s comfort. [If quoting this, include a link to this document: Our full Code of Conduct can be found at this <a href="{{ url_for('render_conduct_page') }}">link</a>.]</p>
-        </div>
-      </div>
-      <div class="row row__center long-form-conduct" id="longformconduct">
-        <div class="column">
-          <h1 class="blue-h1">Long Form Code of Conduct</h1>
-          <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form.</p>
-          <p>This Code of Conduct applies to all Techtonica spaces, Techtonica events (for both members and their guests), and communities, online and off, as well as in one-on-one communications pertaining to Techtonica business. Members violating our Code of Conduct may be penalized or expelled at the discretion of community moderators.</p>
-          <p>Some Techtonica spaces (such as specific Slack channels) may have additional rules in place, which are posted publicly for participants. Participants are responsible for knowing and abiding by these rules. We invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
-          <p>Consequences for noncompliance with the Code of Conduct may include a discussion with mediators, mediation with the member you may have harmed, or as an absolute last resort, a ban from the community.</p>
-            <h3>Behavior</h3>
-            <p class="justify">Harassment includes:
-              <ul>
-                <li>Discriminatory language and actions that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion.</li>
-                <li>Trolling, insults, or personal attacks.</li>
-                <li>Violent or personally objectifying material.</li>
-                <li>Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate.</li>
-                <li>Unwelcome sexual attention.</li>
-                <li>Physical contact and simulated physical contact (e.g., textual descriptions like “backrub”) without consent or after a request to stop.</li>
-                <li>Violent language or threats of violence.</li>
-                <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.</li>
-                <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.</li>
-                <li>Deliberate misgendering or use of “dead” or rejected names.</li>
-                <li>Pattern of inappropriate social contact, such as requesting/assuming unprofessional levels of intimacy with others.</li>
-                <li>Continued one-on-one communication after requests to cease.</li>
-                <li>Deliberate “outing” of any aspect of a person’s identity without their consent.</li>
-                <li>Threatening to post or posting other people’s personally identifiable information without consent.</li>
-                <li>Publication of non-harassing private communication without consent.</li>
-                <li>Blogging, tweeting, or otherwise communicating with intent to harm someone’s reputation, i.e., “making an example” of a member.</li>
-                <li>Intimidation, stalking, or following.</li>
-                <li>Harassing or unwanted photography or recording, including logging online activity for harassment purposes.</li>
-                <li>Sustained, uninvited disruption.</li>
-                <li>Other conduct which could reasonably be considered inappropriate in a professional setting.</li>
-                <li>Advocating for, or encouraging, any of the above behavior.</li>  
-              </ul>
-            </p>
-            <p class="justify">Techtonica prioritizes marginalized people’s safety over privileged people’s comfort. Our moderators will not act on complaints regarding: 
-              <ul>
-                <li>“Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia.”</li>
-                <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
-                <li>Verbal communication in a tone you don’t find pleasant (try focusing on responding to the content or disengaging instead).</li>
-                <li>Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.</li>
-              </ul>
-            </p>
-            <p class="justify">Appropriate behavior contributes to the health, safety, and longevity of the Techtonica community and includes:
-              <ul>
-                <li>Participating in an authentic and empathetic way. </li>
-                <li>Representing Techtonica in a positive, professional way.</li>
-                <li>Using welcoming and inclusive language.</li>
-                <li>Exercising consideration and respect in your speech and actions.</li>
-                <li>Refraining from demeaning, discriminatory, or harassing behavior and speech.</li>
-                <li>Being mindful of your surroundings and of your fellow participants. </li>
-                <li>Considering what is best for the community.</li>
-                <li>Alerting community moderators if you notice a dangerous situation, someone in distress, or unresolved violations of this Code of Conduct.</li>
-                <li>Refraining from doing something you wouldn’t do in another professional situation.</li>
-                <li>Remembering that community event venues may be shared with members of the public; being respectful to all patrons of these locations.</li>
-                <li>Keeping an open and curious mind without making assumptions about others.</li>
-                <li>Attempting collaboration before conflict (see communication tools below).
-Gracefully accepting constructive criticism.</li>
-              </ul>
-            </p>
-            <h3>Enforcement</h3>
-            <p class="justify">
-              <ul>
-                <li>Members and participating guests asked to stop any harassing behavior are expected to comply immediately.</li>
-                <li>If a participant violates the Code of Conduct, community moderators may take any action they deem appropriate to maintaining a welcoming environment for all participants, up to and including expulsion from an event and/or the community and identification of the participant as a violator.</li>
-                <li>If a community moderator is not present at an event, the event organizer should ask violators to leave and then report the situation to community moderators for further deliberation.</li>
-                <li>Community moderators and/or event organizers may take action to redress anything designed to, or with the clear impact of, disrupting or making an environment hostile for any participants.</li>
-                <li>We expect participants to respect the Code of Conduct in all Techtonica communities and at all Techtonica or Techtonica-related events.</li>
-              </ul>
-            </p>
-            <h3>Reporting</h3>
-            <p class="justify">If you experience or witness (or have experienced or have witnessed) violations of the Code of Conduct or have any other concerns, please notify a Techtonica staff member, <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" >info@techtonica.org</a>, or <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">submit an online report here</a>. 
-            </p>
-            <p class="justify">Code of Conduct violations can be reported by:
-              <ul>
-                <li>Emailing <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" >info@techtonica.org</a>.</li>
-                <li>Contacting a staff member privately on via email, by text or phone call, or in person.</li>
-                <li>Communicating with the event organizer (if you’re at an event—all events must come with contact information for an organizer).</li>
-                <li>Anonymous reports can also be made by filling out this <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">form</a>.</li>
-              </ul>
-            </p>
-            <p class="justify">Reports of Code of Conduct violations should include as many details as possible, for example:
-              <ul>
-                <li>Contact info for the reporter (unless anonymous)</li>
-                <li>Names or descriptions of people involved</li>
-                <li>When and where it happened</li>
-                <li>What happened</li>
-                <li>Additional context</li>
-                <li>If the problem is ongoing</li>
-              </ul>
-            </p>
-            <h3>Moderators</h3>
-            <p class="justify">Moderators will:
-              <ul>
-                <li>Work together to respond to violations.</li>
-                <li>Respond as promptly as possible to reports of violations.</li>
-                <li>Make an effort to understand both sides of the situation, including talking to affected members and reading up on the underlying issues, particularly if they don’t have similar personal experience(s).</li>
-                <li>Keep each other accountable.</li>
-                <li>Trade off duties when needed.</li>
-              </ul>
-            </p>
-            <p class="justify">Please see the Techtonica organization documents to learn more about moderators.</p>
-            <h3>Additional Items</h3>
-            <p class="justify">Please also note:
-              <ul>
-                <li>If the person violating the Code of Conduct is a moderator, they will recuse themselves or be excused from handling the incident.</li>
-                <li> Members are responsible for guests. If a guest's behavior violates the Code of Conduct, they could be asked to leave, and could be disallowed from participating in future Techtonica events.</li>
-                <li>Moderators can choose to close threads or ask for a subject change.</li>
-                <li>Moderators can choose to re-evaluate consequences.</li>
-                <li>Do not delete posts or comments you’ve made unless:
-                  <ul>
-                    <li>You sincerely made the post in error (like accidentally posting in the wrong group, for example) and</li>
-                    <li>Deleting will not interfere with group discussion. Deleting because the conversation has become tense or uncomfortable or to avoid taking responsibility is the specific problem we want to address with this rule; many of us are socialized or naturally prone to avoid conflict, but working through that conflict and acknowledging differing viewpoints is worth the discomfort. </li>
-                  </ul>
-                </li>
-                <li>This Code of Conduct applies to Techtonica spaces and events, but if you are being or have been harassed by a Techtonica member externally, you may still report to the Techtonica moderators. We will take all good-faith reports of harassment by Techtonica members seriously. The Techtonica moderators reserve the right to exclude people from the Techtonica community and/or Techtonica events based on past and/or external behavior towards Techtonica members or non-members.</li>
-                <li>Techtonica moderators may reject any report believed to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.</li>
-                <li>We will not name harassment victims without their consent. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Techtonica members or the general public.</li>
-                <li>Reports can be made at any time, but as soon as possible is preferred.</li>
-                <li>Our promise: When taking a private report, our community moderators will ensure you are safe and cannot be overheard. They may involve other moderators to ensure your report is managed properly. Once safe, we'll ask you to tell us about what happened. This can be upsetting, but we'll handle it as respectfully as possible, and you can bring someone to support you. You won't be asked to confront anyone and we won't tell anyone who you are. Our team will be happy to help you contact venue security, local law enforcement, local support services, provide escorts, or otherwise assist you to feel safe. We value your participation.</li>
-              </ul>
-            </p>
-            <p class="justify">Once again, we invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
-            <h3>Sources</h3>
-            <p class="justify">
-            <ul>
-              <li><a href="www.ladynerds.org/code_of_conduct/">“LadyNerds Code of Conduct”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">“Conference anti-harassment/Policy”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy">“Community anti-harassment/Policy”</a></li>
-              <li><a href="http://www.slideshare.net/aeschright/enforcing-your-code-of-conduct-effective-incident-response">“HOWTO design a code of conduct for your community”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Code_of_conduct ">“Code of conduct evaluations”</a></li>
-              <li><a href="http://citizencodeofconduct.org/">“Citizen Code of Conduct”</a></li>
-              <li><a href="http://witchat.github.io/">“WITchat Community Code of Conduct”</a></li>
-              <li><a href="http://contributor-covenant.org/">“Contributor Covenant Code of Conduct”</a></li>
-              <li><a href="https://docs.google.com/document/d/19SqO1kRp7yLXnzZvw1UgSViIh9iVy4KQndgcdHCZHoY/edit?usp=sharing">“Old LadyNerds Code of Conduct”</a></li>
-              <li><a href="http://code-of-conduct.voxmedia.com/">Vox Media’s “Code of Conduct”</a></li>
-            </ul>
-            </p>
-      <div class="row row__center blue-background short-form-conduct" id="shortformconduct">
-<!--         <div class="column">
-          <img src="{{ url_for('static', filename='img/tenderloin-sf-min.jpg') }}" alt="tenderloin neighborhood of san francisco" class="full-width-img">
-        </div> -->
-        <div class="column">
-          <h1>Techtonica Communication Tools (Draft)</h1>
-          <p class="justify">
-            <ul>
-              <li>Don’t hear attack or police tone. Listen for what is behind the words.</li>
-              <li>Resist the urge to attack. Instead, try filling in these blanks: <i>“When [the triggering event] happened, I felt [my feeling] because [my need/interest] is really important to me. Would you be willing to [do a do-able action]?”</i></li>
-              <li>Talk to the other person’s best self.</li>
-              <li>Differentiate needs, interests, and strategies.</li>
-              <li>Acknowledge emotions. See them as signals.</li>
-              <li>Differentiate between acknowledgment and agreement.</li>
-              <li>When listening, avoid making suggestions.</li>
-              <li>Differentiate between evaluation and observation.</li>
-              <li>Test your assumptions. Relinquish them if they prove to be false.</li>
-              <li>Develop curiosity in difficult situations.</li>
-              <li>Assume useful dialogue is possible, even when it seems unlikely.</li>
-              <li>If you are making things worse, stop.</li>
-              <li>Figure out what’s happening, not whose fault it is.</li>
-              <li>Acknowledge conflict. Talk to the right people about the real problem.</li>
-              <li>Assume undiscovered options exist. Seek solutions people willingly support.</li>
-              <li>Be explicit about agreements. Be explicit when they change.</li>
-              <li>Expect and plan for future conflict.</li>
-              <li>If someone calls out your privilege, take a step back. Remember not to require others to educate you, and be grateful to those who do.</li>
-              <li>Use sarcasm carefully. Tone is hard to decipher online; make judicious use of emoji to aid in communication.</li>
-              <li>Apologize when your words have had a hurtful impact. Don’t focus on your intent, and don’t expect forgiveness.</li>
-              <li>Sometimes remaining constructive in a conversation feels like too much work, and it's tempting to lose your temper and flame out. Flaming in the community is very much discouraged. Someone in this community will say something bothersome at some point. Anger is a normal emotion, and we don't want to devalue it or deny your experience. If you need to vent, we do want to encourage you to vent away from the person whose words or actions angered you. If you can't stay constructive, here are some options:
-                <ul>
-                  <li>Ping a moderator.</li>
-                  <li>Vent at a moderator or buddy off-channel.</li>
-                  <li>Ghost out.</li>
-                  <li>Declare you’re done, and leave.</li>
-                </ul>
-              </li>
-            </ul>
-          </p>
-          <p class="justify">Sources:
-            <ul>
-              <li><a href="http://www.amazon.com/Changing-Conversation-Principles-Conflict-Resolution/dp/0143126865">Changing the Conversation: The 17 Principles for Conflict Resolution</a></li>
-              <li><a href="http://tooyoungforthelivingdead.tumblr.com/called-out">“How to deal with being called out”</a></li>
-            </ul>
-          </p>
-        </div>
-      </div>
-      <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" ><img src="{{ url_for('static', filename='img/contact-us.jpg') }}" class="contact" alt="Contact us at info@techtonica.org"></a>
+  <div class="main-header">
+    <div class="main-header__text blue-background">
+      <h1>Techtonica Mission and Code of Conduct</h1>
+      <p>Last modified: 11 September 2016</p>
     </div>
   </div>
+  <div class="row row__center mission" id="mission">
+    <div class="column">
+      <h1 class="blue-h1">Mission</h1>
+      <p class="justify">Techtonica’s mission is to make every engineering team as diverse as its local community while empowering low-income women and non-binary adults through tech training and careers.</p>
+    </div>
+  </div>
+  <div class="row row__center blue-background short-form-conduct" id="shortformconduct">
+    <div class="column">
+      <h1>Short Form Code of Conduct</h1>
+      <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form and we prioritize marginalized people’s safety over privileged people’s comfort. [If quoting this, include a link to this document: Our full Code of Conduct can be found at this <a href="{{ url_for('render_conduct_page') }}">link</a>.]</p>
+    </div>
+  </div>
+  <div class="row row__center long-form-conduct" id="longformconduct">
+    <div class="column">
+      <h1 class="blue-h1">Long Form Code of Conduct</h1>
+      <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form.</p>
+      <p>This Code of Conduct applies to all Techtonica spaces, Techtonica events (for both members and their guests), and communities, online and off, as well as in one-on-one communications pertaining to Techtonica business. Members violating our Code of Conduct may be penalized or expelled at the discretion of community moderators.</p>
+      <p>Some Techtonica spaces (such as specific Slack channels) may have additional rules in place, which are posted publicly for participants. Participants are responsible for knowing and abiding by these rules. We invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
+      <p>Consequences for noncompliance with the Code of Conduct may include a discussion with mediators, mediation with the member you may have harmed, or as an absolute last resort, a ban from the community.</p>
+      <h3>Behavior</h3>
+      <p class="justify">Harassment includes:
+        <ul>
+          <li>Discriminatory language and actions that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion.</li>
+          <li>Trolling, insults, or personal attacks.</li>
+          <li>Violent or personally objectifying material.</li>
+          <li>Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate.</li>
+          <li>Unwelcome sexual attention.</li>
+          <li>Physical contact and simulated physical contact (e.g., textual descriptions like “backrub”) without consent or after a request to stop.</li>
+          <li>Violent language or threats of violence.</li>
+          <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm.</li>
+          <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment.</li>
+          <li>Deliberate misgendering or use of “dead” or rejected names.</li>
+          <li>Pattern of inappropriate social contact, such as requesting/assuming unprofessional levels of intimacy with others.</li>
+          <li>Continued one-on-one communication after requests to cease.</li>
+          <li>Deliberate “outing” of any aspect of a person’s identity without their consent.</li>
+          <li>Threatening to post or posting other people’s personally identifiable information without consent.</li>
+          <li>Publication of non-harassing private communication without consent.</li>
+          <li>Blogging, tweeting, or otherwise communicating with intent to harm someone’s reputation, i.e., “making an example” of a member.</li>
+          <li>Intimidation, stalking, or following.</li>
+          <li>Harassing or unwanted photography or recording, including logging online activity for harassment purposes.</li>
+          <li>Sustained, uninvited disruption.</li>
+          <li>Other conduct which could reasonably be considered inappropriate in a professional setting.</li>
+          <li>Advocating for, or encouraging, any of the above behavior.</li>
+        </ul>
+      </p>
+      <p class="justify">Techtonica prioritizes marginalized people’s safety over privileged people’s comfort. Our moderators will not act on complaints regarding:
+        <ul>
+          <li>“Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia.”</li>
+          <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
+          <li>Verbal communication in a tone you don’t find pleasant (try focusing on responding to the content or disengaging instead).</li>
+          <li>Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.</li>
+        </ul>
+      </p>
+      <p class="justify">Appropriate behavior contributes to the health, safety, and longevity of the Techtonica community and includes:
+        <ul>
+          <li>Participating in an authentic and empathetic way. </li>
+          <li>Representing Techtonica in a positive, professional way.</li>
+          <li>Using welcoming and inclusive language.</li>
+          <li>Exercising consideration and respect in your speech and actions.</li>
+          <li>Refraining from demeaning, discriminatory, or harassing behavior and speech.</li>
+          <li>Being mindful of your surroundings and of your fellow participants. </li>
+          <li>Considering what is best for the community.</li>
+          <li>Alerting community moderators if you notice a dangerous situation, someone in distress, or unresolved violations of this Code of Conduct.</li>
+          <li>Refraining from doing something you wouldn’t do in another professional situation.</li>
+          <li>Remembering that community event venues may be shared with members of the public; being respectful to all patrons of these locations.</li>
+          <li>Keeping an open and curious mind without making assumptions about others.</li>
+          <li>Attempting collaboration before conflict (see communication tools below).
+ully accepting constructive criticism.</li>
+        </ul>
+      </p>
+      <h3>Enforcement</h3>
+      <p class="justify">
+        <ul>
+          <li>Members and participating guests asked to stop any harassing behavior are expected to comply immediately.</li>
+          <li>If a participant violates the Code of Conduct, community moderators may take any action they deem appropriate to maintaining a welcoming environment for all participants, up to and including expulsion from an event and/or the community and identification of the participant as a violator.</li>
+          <li>If a community moderator is not present at an event, the event organizer should ask violators to leave and then report the situation to community moderators for further deliberation.</li>
+          <li>Community moderators and/or event organizers may take action to redress anything designed to, or with the clear impact of, disrupting or making an environment hostile for any participants.</li>
+          <li>We expect participants to respect the Code of Conduct in all Techtonica communities and at all Techtonica or Techtonica-related events.</li>
+        </ul>
+      </p>
+      <h3>Reporting</h3>
+      <p class="justify">If you experience or witness (or have experienced or have witnessed) violations of the Code of Conduct or have any other concerns, please notify a Techtonica staff member, <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" >info@techtonica.org</a>, or <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">submit an online report here</a>.
+      </p>
+      <p class="justify">Code of Conduct violations can be reported by:
+        <ul>
+          <li>Emailing <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" >info@techtonica.org</a>.</li>
+          <li>Contacting a staff member privately on via email, by text or phone call, or in person.</li>
+          <li>Communicating with the event organizer (if you’re at an event—all events must come with contact information for an organizer).</li>
+          <li>Anonymous reports can also be made by filling out this <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">form</a>.</li>
+        </ul>
+      </p>
+      <p class="justify">Reports of Code of Conduct violations should include as many details as possible, for example:
+        <ul>
+          <li>Contact info for the reporter (unless anonymous)</li>
+          <li>Names or descriptions of people involved</li>
+          <li>When and where it happened</li>
+          <li>What happened</li>
+          <li>Additional context</li>
+          <li>If the problem is ongoing</li>
+        </ul>
+      </p>
+      <h3>Moderators</h3>
+      <p class="justify">Moderators will:
+        <ul>
+          <li>Work together to respond to violations.</li>
+          <li>Respond as promptly as possible to reports of violations.</li>
+          <li>Make an effort to understand both sides of the situation, including talking to affected members and reading up on the underlying issues, particularly if they don’t have similar personal experience(s).</li>
+          <li>Keep each other accountable.</li>
+          <li>Trade off duties when needed.</li>
+        </ul>
+      </p>
+      <p class="justify">Please see the Techtonica organization documents to learn more about moderators.</p>
+      <h3>Additional Items</h3>
+      <p class="justify">Please also note:
+        <ul>
+          <li>If the person violating the Code of Conduct is a moderator, they will recuse themselves or be excused from handling the incident.</li>
+          <li> Members are responsible for guests. If a guest's behavior violates the Code of Conduct, they could be asked to leave, and could be disallowed from participating in future Techtonica events.</li>
+          <li>Moderators can choose to close threads or ask for a subject change.</li>
+          <li>Moderators can choose to re-evaluate consequences.</li>
+          <li>Do not delete posts or comments you’ve made unless:
+            <ul>
+              <li>You sincerely made the post in error (like accidentally posting in the wrong group, for example) and</li>
+              <li>Deleting will not interfere with group discussion. Deleting because the conversation has become tense or uncomfortable or to avoid taking responsibility is the specific problem we want to address with this rule; many of us are socialized or naturally prone to avoid conflict, but working through that conflict and acknowledging differing viewpoints is worth the discomfort. </li>
+            </ul>
+          </li>
+          <li>This Code of Conduct applies to Techtonica spaces and events, but if you are being or have been harassed by a Techtonica member externally, you may still report to the Techtonica moderators. We will take all good-faith reports of harassment by Techtonica members seriously. The Techtonica moderators reserve the right to exclude people from the Techtonica community and/or Techtonica events based on past and/or external behavior towards Techtonica members or non-members.</li>
+          <li>Techtonica moderators may reject any report believed to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.</li>
+          <li>We will not name harassment victims without their consent. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Techtonica members or the general public.</li>
+          <li>Reports can be made at any time, but as soon as possible is preferred.</li>
+          <li>Our promise: When taking a private report, our community moderators will ensure you are safe and cannot be overheard. They may involve other moderators to ensure your report is managed properly. Once safe, we'll ask you to tell us about what happened. This can be upsetting, but we'll handle it as respectfully as possible, and you can bring someone to support you. You won't be asked to confront anyone and we won't tell anyone who you are. Our team will be happy to help you contact venue security, local law enforcement, local support services, provide escorts, or otherwise assist you to feel safe. We value your participation.</li>
+        </ul>
+      </p>
+      <p class="justify">Once again, we invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
+      <h3>Sources</h3>
+      <p class="justify">
+      <ul>
+        <li><a href="www.ladynerds.org/code_of_conduct/">“LadyNerds Code of Conduct”</a></li>
+        <li><a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">“Conference anti-harassment/Policy”</a></li>
+        <li><a href="http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy">“Community anti-harassment/Policy”</a></li>
+        <li><a href="http://www.slideshare.net/aeschright/enforcing-your-code-of-conduct-effective-incident-response">“HOWTO design a code of conduct for your community”</a></li>
+        <li><a href="http://geekfeminism.wikia.com/wiki/Code_of_conduct ">“Code of conduct evaluations”</a></li>
+        <li><a href="http://citizencodeofconduct.org/">“Citizen Code of Conduct”</a></li>
+        <li><a href="http://witchat.github.io/">“WITchat Community Code of Conduct”</a></li>
+        <li><a href="http://contributor-covenant.org/">“Contributor Covenant Code of Conduct”</a></li>
+        <li><a href="https://docs.google.com/document/d/19SqO1kRp7yLXnzZvw1UgSViIh9iVy4KQndgcdHCZHoY/edit?usp=sharing">“Old LadyNerds Code of Conduct”</a></li>
+        <li><a href="http://code-of-conduct.voxmedia.com/">Vox Media’s “Code of Conduct”</a></li>
+      </ul>
+      </p>
+      <p class="column centered">
+        <a href="mailto:info@badmail.techtonica.org?Subject=Techtonica%20Contact%20Us" class="contact" target="_blank" ><img src="{{ url_for('static', filename='img/contact-us.jpg') }}" class="contact" alt="Contact us at info@techtonica.org"></a>
+      </p>
+    </div>
 {% endblock content %}


### PR DESCRIPTION
Removed the draft requested in #98, which indirectly fixes the spacing issues in #99. 
I also centered the contact button so it looks more align with the footer social media buttons. 
Also fixed some indentation errors.