### PR TITLE
Work around exception in EB.event_search

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -39,14 +39,18 @@ class Event(object):
 # MAIN HANDLERS
 @app.route("/")
 def render_home_page():
-    # Get Eventbrite details
-    user = eb.get_user()
-    search_params = {"user.id": user["id"], "sort_by": "date", "expand": "venue"}
-    events = eb.event_search(**search_params)
     formatted_events = []
+    try:
+        # Get Eventbrite details
+        user = eb.get_user()
+        search_params = {"user.id": user["id"], "sort_by": "date", "expand": "venue"}
+        events = eb.event_search(**search_params)
+        formatted_events = []
 
-    for e in events["events"]:
-        formatted_events.append(Event(e))
+        for e in events["events"]:
+            formatted_events.append(Event(e))
+    except:
+        pass
 
     """
     Renders the home page from jinja2 template


### PR DESCRIPTION
In the slack we surfaced an issue where the event_search API was throwing an exception for some reason (bad input, api bug, ???): https://gist.github.com/gsong/fc3e53082eb4a1cbbf0e80e87ec89fd2#file-gistfile1-txt-L15-L16

This wraps that call in a try/except and provides an empty fallback so that we don't fail hard if our read from the API goes awry.

It was built and tested on https://staging.techtonica.org