### PR TITLE
Fixing handling of EventBrite failures

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -48,21 +48,17 @@ def render_home_page():
     search_params = {"user.id": user["id"], "sort_by": "date", "expand": "venue"}
     try:
         events = eb.event_search(**search_params)
-    except ValueError as e:
-        # This was happening on 2019-09-21 when Eventbrite was giving back an
-        # HTML-based (instead of JSON-enabled) 403 page -- which said, among
-        # other things, "The Team is currently working to return you to the
-        # service as quickly as possible.".  Hopefully this is exceedingly rare
-        # in most cases, but if and when it does happen, we still want to fail
-        # gracefully.
-        if e.message == "No JSON object could be decoded":
-            events = { "events": [] }
-        else:
-            raise
-    # Now, in principle, it's nice to just detect a known error, like above.
-    # But really, we probably want all exceptions to still fail gracefully, so:
-    except Exception as e:
-        print e
+    # A problem was happening on 2019-09-21 wherein Eventbrite was giving back
+    # an HTML-based (instead of JSON-enabled) 403 page -- which said, among
+    # other things, "The Team is currently working to return you to the service
+    # as quickly as possible.".  Hopefully this is exceedingly rare in most
+    # cases, but if and when it does happen, we still want to fail gracefully.
+
+    # In theory this will be a ValueError, with a .message value of "No JSON
+    # object could be decoded", and we could have a specialized except-handler
+    # for that.  However, it seems to me that we want _all_ exceptions to still
+    # fail gracefully, so just doing a catch-all:
+    except:
         events = { "events": [] }
         pass
 

--- a/main_site.py
+++ b/main_site.py
@@ -39,14 +39,18 @@ class Event(object):
 # MAIN HANDLERS
 @app.route("/")
 def render_home_page():
-    # Get Eventbrite details
-    user = eb.get_user()
-    search_params = {"user.id": user["id"], "sort_by": "date", "expand": "venue"}
-    events = eb.event_search(**search_params)
     formatted_events = []
+    try:
+        # Get Eventbrite details
+        user = eb.get_user()
+        search_params = {"user.id": user["id"], "sort_by": "date", "expand": "venue"}
+        events = eb.event_search(**search_params)
+        formatted_events = []
 
-    for e in events["events"]:
-        formatted_events.append(Event(e))
+        for e in events["events"]:
+            formatted_events.append(Event(e))
+    except:
+        pass
 
     """
     Renders the home page from jinja2 template

--- a/templates/home.html
+++ b/templates/home.html
@@ -59,6 +59,9 @@
       <div class="row row__baseline blue-background">
         <h1>Upcoming Events</h1>
         <div class="row row__center blue-background">
+          {% if not events %}
+            <h3>[Event data currently unavailable. Please check back later!]</h3>
+          {% endif %}
           {% for event in events %}
             <div class="column centered blue-background event-item" id="eventbrite">
               <h3 class="blue-background"><a href="{{event.url}}">{{event.title}}</a></h3>


### PR DESCRIPTION
Causes things to fail relatively gracefully, leaving a message on the page saying that event data is currently unavailable, and to please check back... but fixing the 500 error we were getting when EventBrite gave us a 403 that didn't have JSON data.