### PR TITLE
Add pre-commit hooks to enforce standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# EditorConfig is awesome: http://EditorConfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.py]
+indent_size = 4
+max_line_length = 88

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-.DS_Store
-.sass-cache/
-css/style.css.map
-*.pyc
 *.codekit*
+*.pyc
+.DS_Store
 .env
+.sass-cache/
+.venv
+.vscode
+css/style.css.map
 env
 env*
-.venv
 venv
-.vscode

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,9 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88
+not_skip=__init__.py
+skip=.npm,.python,.pip-cache
+known_third_party = dotenv,eventbrite,flask,flask_sslify,pendulum,requests,sendgrid

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,40 @@
+repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.1.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: detect-private-key
+      - id: mixed-line-ending
+        exclude_types: ["xml"]
+  - repo: local
+    hooks:
+      - id: seed-isort-config
+        name: seed-isort-config
+        entry: bin/seed-isort-config.sh
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [manual]
+  - repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.21
+    hooks:
+      - id: isort
+  - repo: https://github.com/python/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        additional_dependencies: ["flake8-bugbear"]
+  - repo: https://github.com/prettier/prettier
+    rev: 2.0.5
+    hooks:
+      - id: prettier
+minimum_pre_commit_version: "1.21"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ currently hosted on DreamHost.
 - [What](#what)
 - [How](#how)
 - [Getting Started](#getting-started)
+  - [Install Pre-Commit Hooks](#install-pre-commit-hooks)
   - [Running Locally](#running-locally)
   - [Using Docker to Run Locally](#using-docker-to-run-locally)
   - [CSS / SCSS](#css--scss)
@@ -32,7 +33,19 @@ training, mentoring, and hiring.
 
 ## Getting Started
 
-This app uses Python 3.6; please stick to this version.
+This app uses Python 3.6; please stick to this version when doing development.
+
+### Install Pre-Commit Hooks
+
+This project uses various pre-commit hooks to ensure code quality and formatting
+consistency.
+
+1. [`Install pre-commit`](https://pre-commit.com/#install) globally.
+1. Install the project pre-commit hooks:
+
+   ```sh
+   pre-commit install -f --install-hooks
+   ```
 
 ### Running Locally
 
@@ -45,7 +58,7 @@ environments](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 Install the project dependencies. In the project root run:
 
 ```sh
-pip install -r requirements.txt
+pip install -r dev.txt
 ```
 
 Start the application's server:
@@ -78,6 +91,8 @@ To rebuild app: `docker build --tag techtonica .`
 Styling changes should be made to the Sass (.scss) files and then compiled to
 CSS using one of the following commands:
 
+👷‍♀️ **TODO**: Document how install Sass.
+
 ```sh
 sass static/sass/style.scss static/css/style.css
 sass --watch static/sass/style.scss static/css/style.css
@@ -93,6 +108,23 @@ dependencies. If you need to add or remove a Python library dependency:
 
    ```sh
    pip-compile -U
+   ```
+
+Once the new library is used in the code base, you'll need to update the
+[isort](https://timothycrosley.github.io/isort/) config to reflect third party
+library usage:
+
+```sh
+pre-commit run seed-isort-config -a --hook-stage manual
+```
+
+For development dependencies:
+
+1. Edit `dev.in`
+1. Generate `dev.txt`:
+
+   ```sh
+   pip-compile -U dev.in
    ```
 
 ## Deployment to DreamHost

--- a/bin/seed-isort-config.sh
+++ b/bin/seed-isort-config.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+seed-isort-config --application-directories .

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -5,22 +5,38 @@ body {
   line-height: 1.4em;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin: 1.5rem 0;
-  color: #0093B5;
+  color: #0093b5;
   line-height: 1.3em;
   font-weight: 700;
 }
 
-h1, h2 {
+h1,
+h2 {
   letter-spacing: 2px;
 }
 
-h3, h4, h5, h6 {
+h3,
+h4,
+h5,
+h6 {
   letter-spacing: 1px;
 }
 
-body, h1, h2, h3, h4, h5, h6, p {
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
   font-family: "lato", helvetica, sans-serif;
 }
 
@@ -32,7 +48,7 @@ h1 {
 }
 
 a {
-  color: #0093B5;
+  color: #0093b5;
   text-decoration: none;
 }
 
@@ -42,12 +58,12 @@ button {
 }
 
 .blue-h1 {
-  color: #05556D;
+  color: #05556d;
   text-shadow: 0px 0px 1px #ccc;
 }
 
 .blue-background {
-  background-color: #0093B5;
+  background-color: #0093b5;
   color: white;
 }
 .blue-background a {
@@ -56,7 +72,7 @@ button {
   text-shadow: 1px 1px 1px #666;
 }
 .blue-background a:hover {
-  color: #16C1F3;
+  color: #16c1f3;
 }
 
 .centered {
@@ -127,7 +143,7 @@ button {
 }
 
 .nav-link:hover {
-  color: #16C1F3;
+  color: #16c1f3;
 }
 
 .img-link {
@@ -145,7 +161,8 @@ button {
 }
 
 .mc-closeModal {
-  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 1px 1px 0 #000;
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
+    1px 1px 0 #000;
 }
 
 .main-content {
@@ -165,7 +182,8 @@ button {
   justify-content: flex-end;
   width: 100%;
   height: 75vh;
-  background: url(../img/three-participants-at-laptops-min.jpg) #0093B5 no-repeat top right fixed;
+  background: url(../img/three-participants-at-laptops-min.jpg) #0093b5
+    no-repeat top right fixed;
   background-size: cover;
 }
 
@@ -197,7 +215,8 @@ button {
   justify-content: flex-end;
   width: 100%;
   height: 100vh;
-  background: url(../img/apprentices-2019-h2-long-cropped-min.jpg) #0093B5 no-repeat top fixed;
+  background: url(../img/apprentices-2019-h2-long-cropped-min.jpg) #0093b5
+    no-repeat top fixed;
   background-size: cover;
 }
 
@@ -279,7 +298,8 @@ button {
 }
 
 .contact-us,
-.donate, .sponsor {
+.donate,
+.sponsor {
   -webkit-border-radius: 8px;
   -moz-border-radius: 8px;
   -o-border-radius: 8px;
@@ -290,14 +310,15 @@ button {
   text-align: center;
 }
 .contact-us:hover,
-.donate:hover, .sponsor:hover {
-  background-color: #16C1F3;
+.donate:hover,
+.sponsor:hover {
+  background-color: #16c1f3;
   color: white;
   transition: 0.3s;
 }
 
 .sponsor:hover .link-on-blue {
-  color: #05556D;
+  color: #05556d;
 }
 
 .contact-us {
@@ -338,7 +359,7 @@ button {
 }
 
 a:hover {
-  color: #16C1F3;
+  color: #16c1f3;
 }
 
 .sponsor-p {
@@ -469,7 +490,8 @@ table.mentor td:first-of-type {
   .main-header {
     display: block;
     position: relative;
-    background: url(../img/three-participants-at-laptops-min.jpg) #0093B5 no-repeat top center;
+    background: url(../img/three-participants-at-laptops-min.jpg) #0093b5
+      no-repeat top center;
     -webkit-background-size: contain;
     -moz-background-size: contain;
     -o-background-size: contain;
@@ -519,17 +541,18 @@ table.mentor td:first-of-type {
     display: inline-block;
     width: 3rem;
     height: 0.4285714286rem;
-    background: #16C1F3;
+    background: #16c1f3;
     border-radius: 0.2142857143rem;
     transition: 0.3s;
     position: relative;
     /*create the upper and lower lines as pseudo-elements of the middle line*/
   }
-  .lines:before, .lines:after {
+  .lines:before,
+  .lines:after {
     display: inline-block;
     width: 3rem;
     height: 0.4285714286rem;
-    background: #16C1F3;
+    background: #16c1f3;
     border-radius: 0.2142857143rem;
     transition: 0.3s;
     position: absolute;
@@ -559,7 +582,8 @@ table.mentor td:first-of-type {
     background: transparent;
     /*overlay the lines by setting both their top values to 0*/
   }
-  .lines-button.x.close .lines:before, .lines-button.x.close .lines:after {
+  .lines-button.x.close .lines:before,
+  .lines-button.x.close .lines:after {
     transform-origin: 50% 50%;
     top: 0;
     width: 2.5em;
@@ -640,7 +664,8 @@ table.mentor td:first-of-type {
   background-color: #fc7625;
 }
 
-.progress-bg h3.goal, .progress-bg h3.raised {
+.progress-bg h3.goal,
+.progress-bg h3.raised {
   line-height: 78px;
   margin: 0;
   padding: 0;
@@ -680,7 +705,7 @@ table.mentor td:first-of-type {
 }
 
 .collapsible {
-  color: #0093B5;
+  color: #0093b5;
   cursor: pointer;
   margin: 25px;
   text-align: left;
@@ -688,7 +713,7 @@ table.mentor td:first-of-type {
   font-size: 1.2em;
 }
 .collapsible:hover {
-  color: #05556D;
+  color: #05556d;
 }
 .collapsible::before {
   content: "+ ";
@@ -696,7 +721,7 @@ table.mentor td:first-of-type {
 }
 
 .collapsible-active {
-  color: #05556D;
+  color: #05556d;
 }
 .collapsible-active::before {
   content: "- ";

--- a/static/js/collapsible.js
+++ b/static/js/collapsible.js
@@ -1,8 +1,7 @@
-$(document).ready(function() {
-
-  $('.collapsible').click(function() {
-      $(this).toggleClass("collapsible-active");
-      $(this).next(".collapsible-content").toggle();
+$(document).ready(function () {
+  $(".collapsible").click(function () {
+    $(this).toggleClass("collapsible-active");
+    $(this).next(".collapsible-content").toggle();
   });
 
   /* Expanding a collapsible lengthens the page. If you expand one, navigate 
@@ -10,8 +9,8 @@ $(document).ready(function() {
   scroll to the bottom of the page. I could fix this by remembering collapsible
   state in a cookie or something, but the effort/reward ratio is poor. 
   Instead, just scroll back to the top. */
-  if ($('.collapsible')[0]) {
-    $(window).on('beforeunload', function(){
+  if ($(".collapsible")[0]) {
+    $(window).on("beforeunload", function () {
       $(window).scrollTop(0);
     });
   }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -1,47 +1,50 @@
 function openPopupForm() {
-  document.cookie = 'MCEvilPopupClosed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;';
-  require(['mojo/signup-forms/Loader'],
-  function (L) {
-    L.start({'baseUrl':'mc.us13.list-manage.com','uuid':'110f637e29d9b2b5f89664fe8','lid':'22f1ab3b1f'})
+  document.cookie =
+    "MCEvilPopupClosed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+  require(["mojo/signup-forms/Loader"], function (L) {
+    L.start({
+      baseUrl: "mc.us13.list-manage.com",
+      uuid: "110f637e29d9b2b5f89664fe8",
+      lid: "22f1ab3b1f",
+    });
   });
 }
 
 function setCookie(cname, cvalue, exdays) {
   var d = new Date();
-  d.setTime(d.getTime() + (exdays*24*60*60*1000));
-  var expires = 'expires=' + d.toUTCString();
-  document.cookie = cname + '=' + cvalue + '; ' + expires;
+  d.setTime(d.getTime() + exdays * 24 * 60 * 60 * 1000);
+  var expires = "expires=" + d.toUTCString();
+  document.cookie = cname + "=" + cvalue + "; " + expires;
 }
 
 function getCookie(cname) {
-  var name = cname + '=';
-  var ca = document.cookie.split(';');
-  for(var i = 0; i <ca.length; i++) {
+  var name = cname + "=";
+  var ca = document.cookie.split(";");
+  for (var i = 0; i < ca.length; i++) {
     var c = ca[i];
-    while (c.charAt(0) === ' ') {
+    while (c.charAt(0) === " ") {
       c = c.substring(1);
     }
     if (c.indexOf(name) === 0) {
-      return c.substring(name.length,c.length);
+      return c.substring(name.length, c.length);
     }
   }
-  return '';
+  return "";
 }
 
 function cookieExists(cname) {
-  var cookie=getCookie(cname);
-  if (cookie !== '') {
+  var cookie = getCookie(cname);
+  if (cookie !== "") {
     return true;
   } else {
     return false;
   }
 }
 
-$(document).ready(function() {
-
+$(document).ready(function () {
   // check cookie to see if the user has visited if not popup newsletter registration.
-  if (cookieExists('techtonica-visited') === false) {
+  if (cookieExists("techtonica-visited") === false) {
     openPopupForm();
-    setCookie('techtonica-visited', 'yes', 9999)
+    setCookie("techtonica-visited", "yes", 9999);
   }
 });

--- a/static/js/scroll.js
+++ b/static/js/scroll.js
@@ -1,24 +1,26 @@
-$(document).ready(function() {
-
+$(document).ready(function () {
   function scrollDown(name, time) {
-    var aTag = $('.' + name);
-    $('html,body').animate({
-        scrollTop: aTag.offset().top - 75
+    var aTag = $("." + name);
+    $("html,body").animate(
+      {
+        scrollTop: aTag.offset().top - 75,
       },
-      time, 'swing');
+      time,
+      "swing"
+    );
   }
 
-  $('.whatwedo').click(function() {
-    scrollDown('what-we-do', 1000);
+  $(".whatwedo").click(function () {
+    scrollDown("what-we-do", 1000);
   });
 
-  $('.supporters').click(function() {
-    scrollDown('our-supporters', 1000)
+  $(".supporters").click(function () {
+    scrollDown("our-supporters", 1000);
   });
 
-  $('.lines-button').click(function(){
-    $(this).toggleClass('x close');
-    $('.nav-bar').toggleClass('small-screen-nav');
-    $('.nav-link').toggleClass('nav-link--mobile');
+  $(".lines-button").click(function () {
+    $(this).toggleClass("x close");
+    $(".nav-bar").toggleClass("small-screen-nav");
+    $(".nav-link").toggleClass("nav-link--mobile");
   });
 });

--- a/static/sass/_mixins.scss
+++ b/static/sass/_mixins.scss
@@ -7,7 +7,7 @@
   @each $prefix in $prefixes {
     #{'-' + $prefix + '-' + $property}: $value;
   }
- 
+
   // Output standard non-prefixed declaration
   #{$property}: $value;
 }
@@ -19,6 +19,6 @@
   width: $button-size;
   height: $button-size/7;
   background: $light-blue;
-  border-radius: $button-size/14; 
+  border-radius: $button-size/14;
   transition: $transition;
 }

--- a/static/sass/_settings.scss
+++ b/static/sass/_settings.scss
@@ -1,6 +1,6 @@
-$main-blue: #0093B5;
-$light-blue: #16C1F3;
-$dark-blue: #05556D;
+$main-blue: #0093b5;
+$light-blue: #16c1f3;
+$dark-blue: #05556d;
 $white: white;
 $light-gray: #ccc;
 $dark-gray: #666;
@@ -9,8 +9,8 @@ $thin-dark-text-shadow: 1px 1px 1px $dark-gray;
 $thin-light-text-shadow: 0px 0px 1px $light-gray;
 $focal-orange: #fc7625;
 
-$button-size : 3rem; 
-$transition: .3s; // increase this to see the transformations in slow-motion
+$button-size: 3rem;
+$transition: 0.3s; // increase this to see the transformations in slow-motion
 
 body {
   margin: 0;
@@ -19,23 +19,39 @@ body {
   line-height: 1.4em;
 }
 
-h1, h2, h3, h4, h5, h6 {
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
   margin: 1.5rem 0;
   color: $main-blue;
   line-height: 1.3em;
   font-weight: 700;
 }
 
-h1, h2 {
+h1,
+h2 {
   letter-spacing: 2px;
 }
 
-h3, h4, h5, h6 {
+h3,
+h4,
+h5,
+h6 {
   letter-spacing: 1px;
 }
 
-body, h1, h2, h3, h4, h5, h6, p {
-  font-family: 'lato', helvetica, sans-serif;
+body,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+  font-family: "lato", helvetica, sans-serif;
 }
 
 h1 {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1,5 +1,5 @@
-@import 'settings';
-@import 'mixins';
+@import "settings";
+@import "mixins";
 
 .row {
   @include prefix(display, flex, webkit moz);
@@ -69,11 +69,9 @@
   padding-left: 1.25rem;
 }
 
-.mc-closeModal{
-  text-shadow:-1px -1px 0 #000,
-               1px -1px 0 #000,
-               -1px 1px 0 #000,
-                1px 1px 0 #000;
+.mc-closeModal {
+  text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
+    1px 1px 0 #000;
 }
 
 .main-content {
@@ -87,7 +85,8 @@
   justify-content: flex-end;
   width: 100%;
   height: 75vh;
-  background: url(../img/three-participants-at-laptops-min.jpg) $main-blue no-repeat top right fixed;
+  background: url(../img/three-participants-at-laptops-min.jpg) $main-blue
+    no-repeat top right fixed;
   background-size: cover;
 }
 
@@ -102,7 +101,7 @@
   font-size: calc(28px + 24 * (100vw - 320px) / 960);
 
   // Caps max fontsize above x-large-screen breakpoint.
-  @media only screen and (min-width:1200px) {
+  @media only screen and (min-width: 1200px) {
     font-size: 3.5rem;
   }
 }
@@ -114,7 +113,8 @@
   justify-content: flex-end;
   width: 100%;
   height: 100vh;
-  background: url(../img/apprentices-2019-h2-long-cropped-min.jpg) $main-blue no-repeat top fixed;
+  background: url(../img/apprentices-2019-h2-long-cropped-min.jpg) $main-blue
+    no-repeat top fixed;
   background-size: cover;
 }
 
@@ -134,16 +134,16 @@
   width: 100%;
 }
 
-.twenty-percent-width{
-  width:20%;
+.twenty-percent-width {
+  width: 20%;
 }
 
-.ten-percent-width{
-  width:10%;
+.ten-percent-width {
+  width: 10%;
 }
 
 .min-width-250 {
-  min-width:250px;
+  min-width: 250px;
 }
 
 .max-size-75px {
@@ -169,14 +169,14 @@
   max-width: 200px;
 }
 
-.margin-25{
-  margin:25px;
+.margin-25 {
+  margin: 25px;
 }
 
 .fixed-img {
-  width:30%;
-  position:fixed;
-  top:150px;
+  width: 30%;
+  position: fixed;
+  top: 150px;
 }
 
 .hiring {
@@ -190,7 +190,8 @@
 }
 
 .contact-us,
-.donate, .sponsor {
+.donate,
+.sponsor {
   @include prefix(border-radius, 8px, webkit moz o);
   color: $white;
   display: inline-block;
@@ -200,7 +201,7 @@
   &:hover {
     background-color: $light-blue;
     color: $white;
-    transition: .3s;
+    transition: 0.3s;
   }
 }
 
@@ -278,16 +279,16 @@ table.mentor {
 
   td {
     border-bottom: 1px solid #000;
-	padding: 1rem;
+    padding: 1rem;
 
-	ul {
-		margin: 0;
-	}
+    ul {
+      margin: 0;
+    }
   }
 
   td:first-of-type {
     border-right: 1px solid #000;
-	vertical-align: top;
+    vertical-align: top;
   }
 }
 
@@ -300,7 +301,6 @@ table.mentor {
     font-size: 3.5em;
   }
 }
-
 
 @media only screen and (max-width: 910px) {
   .row {
@@ -333,7 +333,6 @@ table.mentor {
     }
   }
 
-
   .nav-bar {
     justify-content: space-between;
   }
@@ -364,7 +363,7 @@ table.mentor {
     background-color: $white;
     text-align: center;
     min-height: 1.4em;
-    z-index: 1
+    z-index: 1;
   }
 
   .nav-link--mobile:last-child {
@@ -374,16 +373,17 @@ table.mentor {
   .main-header {
     display: block;
     position: relative;
-    background: url(../img/three-participants-at-laptops-min.jpg) $main-blue no-repeat top center;
+    background: url(../img/three-participants-at-laptops-min.jpg) $main-blue
+      no-repeat top center;
     @include prefix(background-size, contain, webkit moz o);
   }
 
   .main-header__text {
-        position: absolute;
-        bottom: 0;
-        max-width: 100%;
-        width: auto;
-        padding: 0 1em;
+    position: absolute;
+    bottom: 0;
+    max-width: 100%;
+    width: auto;
+    padding: 0 1em;
   }
 
   .main-content {
@@ -404,7 +404,7 @@ table.mentor {
     top: 0;
     margin: 0.5rem 0;
     padding: $button-size/2 $button-size/3;
-    transition: .3s;
+    transition: 0.3s;
     cursor: pointer;
     user-select: none;
     border-radius: $button-size/7;
@@ -415,7 +415,7 @@ table.mentor {
 
     &:active {
       transition: 0;
-      background: rgba(0,0,0,.1);
+      background: rgba(0, 0, 0, 0.1);
     }
   }
 
@@ -425,23 +425,32 @@ table.mentor {
     position: relative;
 
     /*create the upper and lower lines as pseudo-elements of the middle line*/
-    &:before, &:after {
-     @include line;
+    &:before,
+    &:after {
+      @include line;
       position: absolute;
-        left: 0;
-      content: '';
+      left: 0;
+      content: "";
       transform-origin: $button-size/14 center;
     }
-    &:before { top: $button-size/4; }
-    &:after { top: -$button-size/4; }
+    &:before {
+      top: $button-size/4;
+    }
+    &:after {
+      top: -$button-size/4;
+    }
   }
 
   .lines-button:hover {
     opacity: 1;
 
     .lines {
-      &:before { top: $button-size/3; }
-      &:after { top: -$button-size/3; }
+      &:before {
+        top: $button-size/3;
+      }
+      &:after {
+        top: -$button-size/3;
+      }
     }
   }
 
@@ -450,18 +459,19 @@ table.mentor {
     background: transparent;
 
     /*overlay the lines by setting both their top values to 0*/
-    &:before, &:after {
+    &:before,
+    &:after {
       transform-origin: 50% 50%;
       top: 0;
       width: 2.5em;
     }
 
     // rotate the lines to form the x shape
-    &:before{
-      transform: rotate3d(0,0,1,45deg);
+    &:before {
+      transform: rotate3d(0, 0, 1, 45deg);
     }
-    &:after{
-      transform: rotate3d(0,0,1,-45deg);
+    &:after {
+      transform: rotate3d(0, 0, 1, -45deg);
     }
   }
   .contact-us {
@@ -475,62 +485,44 @@ table.mentor {
 }
 
 /* iphone 4 and 4s media query */
-@media only screen and (min-device-width: 320px)
-  and
-  (max-device-width: 480px)
-  and
-  (-webkit-device-pixel-ratio: 2)
-  and
-  (device-aspect-ratio: 2/3){
-    .main-header__text{
-      font-size: 1rem;
-      height: 50vh;
-    }
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) and (-webkit-device-pixel-ratio: 2) and (device-aspect-ratio: 2/3) {
+  .main-header__text {
+    font-size: 1rem;
+    height: 50vh;
+  }
 }
 
 /* iphone 4 and 4s landscape media query */
-@media only screen
-  and (min-device-width: 320px)
-  and (max-device-width: 480px)
-  and (-webkit-min-device-pixel-ratio: 2)
-  and (orientation: landscape) {
-  .main-header{
+@media only screen and (min-device-width: 320px) and (max-device-width: 480px) and (-webkit-min-device-pixel-ratio: 2) and (orientation: landscape) {
+  .main-header {
     background-size: cover;
     font-size: 14px;
   }
-  .main-content{
+  .main-content {
     font-size: 14px;
   }
 }
 
 /* Samsung Galaxy s5 portrait media query */
-@media screen
-  and (device-width: 360px)
-  and (device-height: 640px)
-  and (-webkit-device-pixel-ratio: 3)
-  and (orientation: portrait) {
-    .main-header__text{
-      font-size: 1rem;
-    }
-    .main-header_text p{
-      margin-bottom: 20px;
-    }
+@media screen and (device-width: 360px) and (device-height: 640px) and (-webkit-device-pixel-ratio: 3) and (orientation: portrait) {
+  .main-header__text {
+    font-size: 1rem;
+  }
+  .main-header_text p {
+    margin-bottom: 20px;
+  }
 }
 
 /* Samsung Galaxy s5 landscape media query */
-@media screen
-  and (device-width: 640px)
-  and (device-height: 360px)
-  and (-webkit-device-pixel-ratio: 3)
-  and (orientation: landscape) {
-    .main-header__text{
-      font-size: 1rem;
-      height: 50vh;
-    }
-    .main-header{
-        height: 500px;
-        background-size: cover;
-    }
+@media screen and (device-width: 640px) and (device-height: 360px) and (-webkit-device-pixel-ratio: 3) and (orientation: landscape) {
+  .main-header__text {
+    font-size: 1rem;
+    height: 50vh;
+  }
+  .main-header {
+    height: 500px;
+    background-size: cover;
+  }
 }
 
 .progress-bg {
@@ -539,9 +531,9 @@ table.mentor {
   height: 78px;
   border-radius: 10px;
   text-align: center;
-  -moz-box-shadow:    inset 0 0 10px $light-gray;
+  -moz-box-shadow: inset 0 0 10px $light-gray;
   -webkit-box-shadow: inset 0 0 10px black;
-  box-shadow:         inset 0 0 10px black;
+  box-shadow: inset 0 0 10px black;
   background-color: $white;
 }
 
@@ -550,10 +542,11 @@ table.mentor {
   border-radius: 10px;
   float: left;
   width: 50%;
-  background-color: $focal-orange; 
+  background-color: $focal-orange;
 }
 
-.progress-bg h3.goal, .progress-bg h3.raised {
+.progress-bg h3.goal,
+.progress-bg h3.raised {
   line-height: 78px;
   margin: 0;
   padding: 0;
@@ -600,7 +593,7 @@ table.mentor {
   text-align: left;
   outline: none;
   font-size: 1.2em;
-  &:hover{
+  &:hover {
     color: $dark-blue;
   }
   &::before {

--- a/templates/apprenticeship.html
+++ b/templates/apprenticeship.html
@@ -1,182 +1,389 @@
-{% extends "base.html" %}
+{% extends "base.html" %} {% block title %} Techtonica Apprenticeship {%
+endblock title %} {% block content %}
+<div class="main-content">
+  <div class="apprenticeship-header" title="Apprentices">
+    <div class="main-header__text blue-background">
+      <h1 class="main-header__header">Apprenticeship</h1>
+      <p>
+        Techtonica's software engineering apprenticeship program is six months
+        of free, intensive, hands-on tech learning for local women and
+        non-binary adults with low incomes.
+      </p>
+    </div>
+  </div>
+  <div class="row row__center what-we-do" id="whatwedo">
+    <div class="column">
+      <h1 class="blue-h1">The Program</h1>
+      <p class="justify">
+        Techtonica's apprenticeship program is a free, full-time, six-month
+        program that provides the opportunity for local women and non-binary,
+        femme adults with low incomes to learn technical skills and start their
+        first job in tech. We select apprentices who are independent but good at
+        collaborating, motivated to succeed, dedicated to the commitment of
+        learning to code, flexible, curious, open-minded, and excited for
+        long-term careers in the field, have a good attitude and a growth
+        mindset, can calmly manage extended periods of frustration
+        (troubleshooting is something you'll face forever in tech!), and want to
+        pay it forward. We aim to empower those most underrepresented in tech
+        and to help tech become more diverse and inclusive.
+      </p>
+      <p class="justify">
+        92% of our participants so far have been people of color, 25% have a
+        disability, 10% identify outside the gender binary, and 8% are veterans.
+      </p>
+      <p class="justify">
+        The program runs Monday through Friday, 8:30 AM to 5:30 PM for six
+        months in San Francisco, starting in January and July. After the first
+        trial month of full-time training, participants who work the hardest and
+        meet and exceed expectations will be invited to continue for the last
+        five months with stipends based upon need and funding available. (We
+        still recommend you save up as much as possible as stipends may not
+        cover all your costs.)
+      </p>
+      <p class="justify">
+        Techtonica apprentices will learn to do full-stack web development using
+        JavaScript. Upon successful completion of the program, as many
+        apprentices as possible are placed with partner companies via a two-way
+        interview and rating system. If you and the company you are placed with
+        meet the requirements, you may earn an OJT ("On-the-Job Training")
+        certificate from the State of California's Division of Apprenticeship
+        Standards.
+      </p>
+      <p class="justify">
+        What bootcamps and Techtonica have in common is the fact that they are
+        intensive training. However, bootcamps can be pretty passive classroom
+        learning with students and they cost between $15,000 and $30,000.
+        Techtonica aims to be more like the workplace to make the transition
+        into the industry better—instead of having an instructor constantly
+        guiding you (which you won't have in any software engineering job), you
+        are given a general schedule of topics and assignments (see [our
+        curriculum repo](https://github.com/techtonica/curriculum) for an idea
+        of the resources provided) and you're expected to figure out what to do
+        on your own or in collaboration with volunteers, mentors, tech groups,
+        and other apprentices. Because our resources are open-source, they are
+        continuously being improved and you can even make improvements as you
+        work through them. In the best jobs, there are regular check-ins with
+        very understanding managers and mentors provide regular support, but
+        that is not always the case. Techtonica’s program is as hands-on and
+        project-based as possible to best prepare you for work in tech. You'll
+        also be expected to speak and present in front of people often—a very
+        useful skill to have for a successful career.
+      </p>
+      <p class="justify">
+        The schedule includes assessments to give you a reason to review what
+        you've learned, to provide you with feedback on where you need to
+        improve, and to prepare you for successful placement. As we consider
+        your progress, we take everything you do in the program into account
+        (not just assessments)—if you're on time and present, if you're meeting
+        deadlines, if you're completing assignments, if you're following
+        process, if you're communicating about your needs, if you're
+        consistently meeting with your mentors, if you're building your network,
+        if you're collaborating well, if you're solving problems, if you're
+        dealing with the stress of an intensive program well, if you're lifting
+        others with you, if you're reading instructions, how your mentor feels
+        you're doing, how you indicate you're doing in surveys and one-on-ones,
+        etc. If we see any indications you’re struggling in one area, we look
+        more closely at everything else and we seek a plan for improvement.
+        Consistent problems and lack of improvement could indicate someone’s not
+        ready to continue the program. The board discusses such cases to decide
+        what should be done.
+      </p>
+      <p class="justify">
+        Intensive programs, career transitions, and learning and working with
+        technical concepts—these are all stressful, difficult things. If we
+        accept you to our program, we believe in your ability to step up to the
+        challenge, and you should believe in that ability and look at every new
+        step as something preparing you for tech. In many ways, tech will be
+        much harder than this program and this is your chance to work out how
+        you’re going to react when faced with bigger challenges. Are you able to
+        train yourselves to calmly accept challenges, to open your minds to
+        growth, and to learn whatever’s needed to succeed?
+      </p>
+    </div>
+    <div class="column">
+      <img
+        src="{{ url_for('static', filename='img/practice-interviewing-at-Symantec-min.jpg') }}"
+        alt="Three women talk technical interviewing at Symantec."
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/two-way-interview-min.jpg') }}"
+        alt="Two people from a company interviewing an apprentice."
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/coding-on-a-whiteboard-min.jpg') }}"
+        alt="Black woman coding on a whiteboard."
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/four-smiling-people-at-laptops.jpg') }}"
+        alt="Four women sitting at laptops and smiling."
+        class="full-width-img"
+      />
+    </div>
+  </div>
+  <div class="row row__center blue-background why-why" id="why">
+    <div class="column">
+      <img
+        src="{{ url_for('static', filename='img/interview-practice-min.jpg') }}"
+        alt="Two Asian women practicing technical interviewing."
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/whiteboarding-practice-min.jpg') }}"
+        alt="Two people practicing technical whiteboarding."
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/final-project-presentation-min.jpg') }}"
+        alt="Black woman presenting her software project."
+        class="full-width-img"
+      />
+    </div>
+    <div class="column">
+      <h1>Eligibility</h1>
+      <p class="justify">
+        You are eligible to apply for Techtonica’s full-time program if you:
+      </p>
+      <ul>
+        <li>are a woman (cis OR trans) or non-binary adult</li>
+        <li>
+          are digitally literate, meaning you are very familiar and good with
+          computers and the internet, can type 40+ WPM with accuracy, and you
+          know how to use a mouse/trackpad, browsers, and email
+        </li>
+        <li>
+          at the very least graduated from high school or received your GED
+        </li>
+        <li>can commit to always being present and on time and prepared</li>
+        <li>are dedicated to building a long-term career in tech</li>
+        <li>have less than $50,000 in annual income and net worth</li>
+        <li>have lived in the Bay Area for at least one year</li>
+        <li>
+          have housing that will be stable for the entirety of the six months of
+          the program and six months of placement
+        </li>
+        <li>are legally employable in the United States</li>
+        <li>
+          agree to work at whichever partner company we match you with upon
+          successful completion of the program
+        </li>
+        <li>
+          are willing to appear in Techtonica's media and pitch yourself to
+          Techtonica's partners
+        </li>
+        <li>
+          have not attended a full-time coding bootcamp or completed a C.S.
+          degree in the last six years
+        </li>
+        <li>
+          have not already worked as a software engineer or web developer in the
+          last six years
+        </li>
+        <li>
+          agree to abide by
+          <a
+            href="{{ url_for('render_conduct_page') }}"
+            title="Code of Conduct"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Techtonica's Code of Conduct</a
+          >,
+          <a
+            href="https://docs.google.com/document/d/1bPp3wT4YUo2PuNSYLMwIW9TkU6trd7NSuR9ieHv9MME/edit?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Participant Handbook</a
+          >, and
+          <a
+            href="https://docs.google.com/document/d/1mLzYmGJKu3AIzfkblI5bSuiREZ_leUJrG8gs5gcoHSw/edit?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Apprenticeship Agreement</a
+          >
+        </li>
+      </ul>
+      <p class="justify">You are probably not a good fit if you:</p>
+      <ul>
+        <li>would rather be passively trained than learn through discovery</li>
+        <li>prefer always being told exactly what to do</li>
+        <li>don't like when plans change</li>
+        <li>can't advocate for yourself</li>
+        <li>don't like details</li>
+        <li>don't get along with everyone</li>
+        <li>are quickly frustrated every time you get stuck on a problem</li>
+        <li>
+          don't feel comfortable asking questions until you understand
+          complicated concepts
+        </li>
+        <li>
+          can't lay aside learning everything about something in place of just
+          learning enough to make progress on your work
+        </li>
+        <li>take longer than most people to learn and apply new concepts</li>
+      </ul>
+    </div>
+  </div>
+  <div class="row row__baseline how-it-works" id="howitworks">
+    <h1 class="blue-h1">Application Process</h1>
+    <div class="row">
+      <div class="column column-med centered">
+        <h3>1. Interest and long application forms</h3>
+        <p>
+          Thoroughly fill out and submit the interest form (which will open for
+          a few weeks every fall and spring) and the long application form
+          (linked to upon submitting the first form—the long form will take some
+          time, so don't start too late!) by the deadline.
+        </p>
+      </div>
+      <div class="column column-med centered">
+        <h3>
+          2. Two invite-only digital literacy testing and JavaScript events
+        </h3>
+        <p>
+          Participate in two of the events offered (details will be sent upon
+          submission of the long form).
+        </p>
+      </div>
+      <div class="column column-med centered">
+        <h3>3. Code challenges</h3>
+        <p>Complete a take-home code challenge.</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="column column-med centered">
+        <h3>4. Staff interviews</h3>
+        <p>Participate in staff interviews.</p>
+      </div>
+      <div class="column column-med centered">
+        <h3>5. Board interviews</h3>
+        <p>Participate in board interviews.</p>
+      </div>
+    </div>
+    <div class="row">
+      <div class="column column-med centered">
+        <h2>
+          <a
+            href="http://bit.ly/free-coding-classes"
+            class="sponsor"
+            target="_blank"
+            >Applications have been delayed due to COVID-19. We hope to open
+            them again soon!</a
+          >
+        </h2>
+      </div>
+    </div>
+    <div class="row">
+      <div class="column column-med centered">
+        <p>
+          Accepted applicants will be required to submit some more information
+          to confirm participation and to join onboarding on the Saturday one
+          month before the start date. You'll also be given some pre-work to
+          complete before the start of the full-time training.
+        </p>
+      </div>
+    </div>
+  </div>
+  <div class="row row__center blue-background howtohelp">
+    <div class="column how-to-help" id="howtohelp">
+      <h1>What We Look For</h1>
+      <p class="justify">
+        This program is very competitive; we select participants who
+        continuously prove that they are:
+      </p>
 
-{% block title %}
-  Techtonica Apprenticeship
-{% endblock title %}
-
-{% block content %}
-  <div class="main-content">
-      <div class="apprenticeship-header" title="Apprentices">
-        <div class="main-header__text blue-background">
-          <h1 class="main-header__header">Apprenticeship</h1>
-          <p>Techtonica's software engineering apprenticeship program is six months of free, intensive, hands-on tech learning for local women and non-binary adults with low incomes.
-          </p>
-        </div>
+      <ul>
+        <li>self-motivated</li>
+        <li>resilient</li>
+        <li>logical</li>
+        <li>humble</li>
+        <li>respectful</li>
+        <li>independent</li>
+        <li>curious</li>
+        <li>open-minded</li>
+        <li>flexible</li>
+        <li>persistent</li>
+        <li>optimistic</li>
+        <li>punctual</li>
+        <li>committed</li>
+        <li>communicative</li>
+        <li>collaborative</li>
+        <li>responsive to feedback</li>
+        <li>willing to ask questions</li>
+        <li>long-term goal setters</li>
+        <li>able to deal with stress well</li>
+        <li>able and willing to work with anyone</li>
+        <li>take pride in owning their learning</li>
+        <li>always curious and ready to learn and improve</li>
+        <li>transparent and compassionate communicators</li>
+        <li>hard-working and ready to make sacrifices</li>
+        <li>dedicated to seeing things through to the end</li>
+        <li>
+          willing to meet the
+          <a
+            href="https://docs.google.com/document/d/1IWny-IXB-XDWW21l3JODwPuh1QOVBFQbii_DjvF0g00/edit?usp=sharing"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Apprenticeship Expectations</a
+          >, including abiding by
+          <a href="/conduct">Techtonica's Code of Conduct</a>
+        </li>
+      </ul>
+    </div>
+    <div class="column">
+      <img
+        src="{{ url_for('static', filename='img/presenting-at-event-min.jpg') }}"
+        alt="Person giving a talk at an event"
+        class="full-width-img"
+      />
+      <img
+        src="{{ url_for('static', filename='img/person-at-desk-with-monitor-and-laptop-min.jpg') }}"
+        alt="Latina woman coding at a desk with monitor and laptop."
+        class="full-width-img"
+      />
+    </div>
+  </div>
+  <div class="row row__baseline how-it-works" id="howitworks">
+    <h1 class="blue-h1">How to Prepare</h1>
+    <div class="row">
+      <div class="column column-med centered">
+        <h3>
+          1. Learn as much JavaScript ahead of time as possible—<a
+            href="http://freecodecamp.org"
+            >Free Code Camp</a
+          >
+          and <a>Codecademy</a> are great for this.
+        </h3>
       </div>
-      <div class="row row__center what-we-do" id="whatwedo">
-        <div class="column">
-          <h1 class="blue-h1">The Program</h1>
-          <p class="justify">Techtonica's apprenticeship program is a free, full-time, six-month program that provides the opportunity for local women and non-binary, femme adults with low incomes to learn technical skills and start their first job in tech. We select apprentices who are independent but good at collaborating, motivated to succeed, dedicated to the commitment of learning to code, flexible, curious, open-minded, and excited for long-term careers in the field, have a good attitude and a growth mindset, can calmly manage extended periods of frustration (troubleshooting is something you'll face forever in tech!), and want to pay it forward. We aim to empower those most underrepresented in tech and to help tech become more diverse and inclusive.</p>
-          <p class="justify">92% of our participants so far have been people of color</strong>, 25% have a disability, 10% identify outside the gender binary, 
-          and 8% are veterans.</p>
-          <p class="justify">The program runs Monday through Friday, 8:30 AM to 5:30 PM for six months in San Francisco, starting in January and July. After the first trial month of full-time training, participants who work the hardest and meet and exceed expectations will be invited to continue for the last five months with stipends based upon need and funding available. (We still recommend you save up as much as possible as stipends may not cover all your costs.)</p>
-          <p class="justify">Techtonica apprentices will learn to do full-stack web development using JavaScript. Upon successful completion of the program, as many apprentices as possible are placed with partner companies via a two-way interview and rating system. If you and the company you are placed with meet the requirements, you may earn an OJT ("On-the-Job Training") certificate from the State of California's Division of Apprenticeship Standards.</p>
-          <p class="justify">What bootcamps and Techtonica have in common is the fact that they are intensive training. However, bootcamps can be pretty passive classroom learning with students and they cost between $15,000 and $30,000. Techtonica aims to be more like the workplace to make the transition into the industry better—instead of having an instructor constantly guiding you (which you won't have in any software engineering job), you are given a general schedule of topics and assignments (see [our curriculum repo](https://github.com/techtonica/curriculum) for an idea of the resources provided) and you're expected to figure out what to do on your own or in collaboration with volunteers, mentors, tech groups, and other apprentices. Because our resources are open-source, they are continuously being improved and you can even make improvements as you work through them. In the best jobs, there are regular check-ins with very understanding managers and mentors provide regular support, but that is not always the case. Techtonica’s program is as hands-on and project-based as possible to best prepare you for work in tech. You'll also be expected to speak and present in front of people often—a very useful skill to have for a successful career.
-          </p>
-          <p class="justify">The schedule includes assessments to give you a reason to review what you've learned, to provide you with feedback on where you need to improve, and to prepare you for successful placement. As we consider your progress, we take everything you do in the program into account (not just assessments)—if you're on time and present, if you're meeting deadlines, if you're completing assignments, if you're following process, if you're communicating about your needs, if you're consistently meeting with your mentors, if you're building your network, if you're collaborating well, if you're solving problems, if you're dealing with the stress of an intensive program well, if you're lifting others with you, if you're reading instructions, how your mentor feels you're doing, how you indicate you're doing in surveys and one-on-ones, etc. If we see any indications you’re struggling in one area, we look more closely at everything else and we seek a plan for improvement. Consistent problems and lack of improvement could indicate someone’s not ready to continue the program. The board discusses such cases to decide what should be done.</p>
-          <p class="justify">Intensive programs, career transitions, and learning and working with technical concepts—these are all stressful, difficult things. If we accept you to our program, we believe in your ability to step up to the challenge, and you should believe in that ability and look at every new step as something preparing you for tech. In many ways, tech will be much harder than this program and this is your chance to work out how you’re going to react when faced with bigger challenges. Are you able to train yourselves to calmly accept challenges, to open your minds to growth, and to learn whatever’s needed to succeed?</p>
-        </div>
-        <div class="column">
-          <img src="{{ url_for('static', filename='img/practice-interviewing-at-Symantec-min.jpg') }}" alt="Three women talk technical interviewing at Symantec." class="full-width-img">
-          <img src="{{ url_for('static', filename='img/two-way-interview-min.jpg') }}" alt="Two people from a company interviewing an apprentice." class="full-width-img">
-          <img src="{{ url_for('static', filename='img/coding-on-a-whiteboard-min.jpg') }}" alt="Black woman coding on a whiteboard." class="full-width-img">
-          <img src="{{ url_for('static', filename='img/four-smiling-people-at-laptops.jpg') }}" alt="Four women sitting at laptops and smiling." class="full-width-img">
-        </div>
+      <div class="column column-med centered">
+        <h3>
+          2. Attend coding meetups, like the
+          <a href="https://www.meetup.com/Women-Who-Code-SF/">Women Who Code</a>
+          JavaScript study group to practice getting to know people.
+        </h3>
       </div>
-      <div class="row row__center blue-background why-why" id="why">
-        <div class="column">
-          <img src="{{ url_for('static', filename='img/interview-practice-min.jpg') }}" alt="Two Asian women practicing technical interviewing." class="full-width-img">
-          <img src="{{ url_for('static', filename='img/whiteboarding-practice-min.jpg') }}" alt="Two people practicing technical whiteboarding." class="full-width-img">
-          <img src="{{ url_for('static', filename='img/final-project-presentation-min.jpg') }}" alt="Black woman presenting her software project." class="full-width-img">
-        </div>
-        <div class="column">
-          <h1>Eligibility</h1>
-          <p class="justify">You are eligible to apply for Techtonica’s full-time program if you:
-            <ul>
-              <li>are a woman (cis OR trans) or non-binary adult</li>
-              <li>are digitally literate, meaning you are very familiar and good with computers and the internet, can type 40+ WPM with accuracy, and you know how to use a mouse/trackpad, browsers, and email</li>
-              <li>at the very least graduated from high school or received your GED</li>
-              <li>can commit to always being present and on time and prepared</li>
-              <li>are dedicated to building a long-term career in tech</li>
-              <li>have less than $50,000 in annual income and net worth</li>
-              <li>have lived in the Bay Area for at least one year</li>
-              <li>have housing that will be stable for the entirety of the six months of the program and six months of placement</li>
-              <li>are legally employable in the United States</li>
-              <li>agree to work at whichever partner company we match you with upon successful completion of the program</li>
-              <li>are willing to appear in Techtonica's media and pitch yourself to Techtonica's partners</li>
-              <li>have not attended a full-time coding bootcamp or completed a C.S. degree in the last six years</li>
-              <li>have not already worked as a software engineer or web developer in the last six years</li>
-              <li>agree to abide by <a href="{{ url_for('render_conduct_page') }}" title="Code of Conduct" target="_blank" rel="noopener noreferrer">Techtonica's Code of Conduct</a>, <a href="https://docs.google.com/document/d/1bPp3wT4YUo2PuNSYLMwIW9TkU6trd7NSuR9ieHv9MME/edit?usp=sharing" target="_blank" rel="noopener noreferrer">Participant Handbook</a>, and <a href="https://docs.google.com/document/d/1mLzYmGJKu3AIzfkblI5bSuiREZ_leUJrG8gs5gcoHSw/edit?usp=sharing" target="_blank" rel="noopener noreferrer">Apprenticeship Agreement</a></li>
-            </ul>
-          </p>
-          <p class="justify">You are probably not a good fit if you:
-            <ul>
-              <li>would rather be passively trained than learn through discovery</li>
-              <li>prefer always being told exactly what to do</li>
-              <li>don't like when plans change</li>
-              <li>can't advocate for yourself</li>
-              <li>don't like details</li>
-              <li>don't get along with everyone</li>
-              <li>are quickly frustrated every time you get stuck on a problem</li>
-              <li>don't feel comfortable asking questions until you understand complicated concepts</li>
-              <li>can't lay aside learning everything about something in place of just learning enough to make progress on your work</li>
-              <li>take longer than most people to learn and apply new concepts</li>
-            </ul>
-          </p>
-        </div>
+      <div class="column column-med centered">
+        <h3>3. Develop your typing and Mac keyboard shortcut skills.</h3>
       </div>
-      <div class="row row__baseline how-it-works" id="howitworks">
-        <h1 class="blue-h1">Application Process</h1>
-        <div class="row">
-          <div class="column column-med centered">
-            <h3>1. Interest and long application forms</h3>
-            <p>Thoroughly fill out and submit the interest form (which will open for a few weeks every fall and spring) and the long application form (linked to upon submitting the first form—the long form will take some time, so don't start too late!) by the deadline.
-            </p>
-          </div>
-          <div class="column column-med centered">
-            <h3>2. Two invite-only digital literacy testing and JavaScript events</h3>
-            <p>Participate in two of the events offered (details will be sent upon submission of the long form).</p>
-          </div>
-          <div class="column column-med centered">
-            <h3>3. Code challenges</h3>
-            <p>Complete a take-home code challenge.</p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="column column-med centered">
-            <h3>4. Staff interviews</h3>
-            <p>Participate in staff interviews.</p>
-          </div>
-          <div class="column column-med centered">
-            <h3>5. Board interviews</h3>
-            <p>Participate in board interviews.</p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="column column-med centered">
-            <h2><a href="http://bit.ly/free-coding-classes" class="sponsor" target="_blank">Applications have been delayed due to COVID-19. We hope to open them again soon!</a></h2>
-          </div>
-        </div>
-        <div class="row">
-          <div class="column column-med centered">
-            <p>Accepted applicants will be required to submit some more information to confirm participation and to join onboarding on the Saturday one month before the start date. You'll also be given some pre-work to complete before the start of the full-time training.</p>
-          </div>
-        </div>
+    </div>
+    <div class="row">
+      <div class="column column-med centered">
+        <h3>
+          4. Learn about different Bay Area companies and long-term pathways in
+          tech to start getting an idea of your career goals.
+        </h3>
       </div>
-      <div class="row row__center blue-background howtohelp">
-        <div class="column how-to-help" id="howtohelp">
-          <h1>What We Look For</h1>
-                  <p class="justify">
-             This program is very competitive; we select participants who continuously prove that they are:
-          <p class="justify">
-            <ul>
-              <li>self-motivated</li>
-              <li>resilient</li>
-              <li>logical</li>
-              <li>humble</li>
-              <li>respectful</li>
-              <li>independent</li>
-              <li>curious</li>
-              <li>open-minded</li>
-              <li>flexible</li>
-              <li>persistent</li>
-              <li>optimistic</li>
-              <li>punctual</li>
-              <li>committed</li>
-              <li>communicative</li>
-              <li>collaborative</li>
-              <li>responsive to feedback</li>
-              <li>willing to ask questions</li>
-              <li>long-term goal setters</li>
-              <li>able to deal with stress well</li>
-              <li>able and willing to work with anyone</li>
-              <li>take pride in owning their learning</li>
-              <li>always curious and ready to learn and improve</li>
-              <li>transparent and compassionate communicators</li>
-              <li>hard-working and ready to make sacrifices</li>
-              <li>dedicated to seeing things through to the end</li>
-              <li>willing to meet the <a href="https://docs.google.com/document/d/1IWny-IXB-XDWW21l3JODwPuh1QOVBFQbii_DjvF0g00/edit?usp=sharing" target="_blank" rel="noopener noreferrer">Apprenticeship Expectations</a>, including abiding by <a href="/conduct">Techtonica's Code of Conduct</a></li>
-            </ul>
-          </p>
-        </div>
-        <div class="column">
-          <img src="{{ url_for('static', filename='img/presenting-at-event-min.jpg') }}" alt="Person giving a talk at an event" class="full-width-img">
-          <img src="{{ url_for('static', filename='img/person-at-desk-with-monitor-and-laptop-min.jpg') }}" alt="Latina woman coding at a desk with monitor and laptop." class="full-width-img">
-        </div>
+      <div class="column column-med centered">
+        <h3>5. Practice learning and applying concepts quickly.</h3>
       </div>
-      <div class="row row__baseline how-it-works" id="howitworks">
-        <h1 class="blue-h1">How to Prepare</h1>
-        <div class="row">
-          <div class="column column-med centered">
-            <h3>1. Learn as much JavaScript ahead of time as possible—<a href="http://freecodecamp.org">Free Code Camp</a> and <a>Codecademy</a> are great for this.</h3>
-          </div>
-          <div class="column column-med centered">
-            <h3>2. Attend coding meetups, like the <a href="https://www.meetup.com/Women-Who-Code-SF/">Women Who Code</a> JavaScript study group to practice getting to know people.</h3>
-          </div>
-          <div class="column column-med centered">
-            <h3>3. Develop your typing and Mac keyboard shortcut skills.</h3>
-          </div>
-        </div>
-        <div class="row">
-          <div class="column column-med centered">
-            <h3>4. Learn about different Bay Area companies and long-term pathways in tech to start getting an idea of your career goals.</h3>
-          </div>
-          <div class="column column-med centered">
-            <h3>5. Practice learning and applying concepts quickly.</h3>
-          </div>
-          <div class="column column-med centered">
-            <h3>6. Practice talking out loud about your thought process and collaborating with others.</h3>
-          </div>
-        </div>
+      <div class="column column-med centered">
+        <h3>
+          6. Practice talking out loud about your thought process and
+          collaborating with others.
+        </h3>
       </div>
-{% endblock content %}
+    </div>
+  </div>
+  {% endblock content %}
+</div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,40 +1,121 @@
-<!doctype html>
+<!DOCTYPE html>
 <html class="no-js" lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="google-site-verification" content="SBEOwaB6Oumg3YDk1clhzVE3EeBmdzfsVTOve_iQIeg" />
+    <meta
+      name="google-site-verification"
+      content="SBEOwaB6Oumg3YDk1clhzVE3EeBmdzfsVTOve_iQIeg"
+    />
     <title>
-      {% block title %}
-        Techtonica: Bridging the Tech Gap
-      {% endblock title %}
+      {% block title %} Techtonica: Bridging the Tech Gap {% endblock title %}
     </title>
-    <meta name="description" content="We partner with tech companies to offer tech apprenticeships with living and childcare stipends and job placement to local women and non-binary adults with low incomes." />
-    <meta name="keywords" content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, low income, free tech training, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer adults, adult education, vocational training, tech jobs, San Francisco, sf, software engineering, learn to code, software developer school, Michelle Glauser" />
-    <meta property="og:title" content="Techtonica: Bridging the Tech Gap"/>
-    <meta property="og:description" content="Tuition-free tech training with living stipends and job placement at sponsoring companies for women and non-binary adults with low incomes."/>
-    <meta property="og:type" content="website"/>
-    <meta property="og:url" content="http://techtonica.org"/>
-    <meta property="og:image" content="{{ url_for('static', filename='img/three-participants-at-laptops-min.jpg') }}"/>
-    <link href="{{ url_for('static', filename='img/favicon.ico') }}" rel="icon" type="image/x-icon" />
+    <meta
+      name="description"
+      content="We partner with tech companies to offer tech apprenticeships with living and childcare stipends and job placement to local women and non-binary adults with low incomes."
+    />
+    <meta
+      name="keywords"
+      content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, low income, free tech training, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer adults, adult education, vocational training, tech jobs, San Francisco, sf, software engineering, learn to code, software developer school, Michelle Glauser"
+    />
+    <meta property="og:title" content="Techtonica: Bridging the Tech Gap" />
+    <meta
+      property="og:description"
+      content="Tuition-free tech training with living stipends and job placement at sponsoring companies for women and non-binary adults with low incomes."
+    />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="http://techtonica.org" />
+    <meta
+      property="og:image"
+      content="{{ url_for('static', filename='img/three-participants-at-laptops-min.jpg') }}"
+    />
+    <link
+      href="{{ url_for('static', filename='img/favicon.ico') }}"
+      rel="icon"
+      type="image/x-icon"
+    />
 
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}" />
-    <link rel="preload" href="{{ url_for('static', filename='img/three-participants-at-laptops-min.jpg') }}" as="image">
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/style.css') }}"
+    />
+    <link
+      rel="preload"
+      href="{{ url_for('static', filename='img/three-participants-at-laptops-min.jpg') }}"
+      as="image"
+    />
     <script>
-      (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', 'UA-74406248-1', 'auto');ga('create', 'UA-94034379-1', 'auto', 'adHawks');ga('send', 'pageview');ga('adHawks.send', 'pageview');
+      (function (i, s, o, g, r, a, m) {
+        i["GoogleAnalyticsObject"] = r;
+        (i[r] =
+          i[r] ||
+          function () {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
+      );
+      ga("create", "UA-74406248-1", "auto");
+      ga("create", "UA-94034379-1", "auto", "adHawks");
+      ga("send", "pageview");
+      ga("adHawks.send", "pageview");
     </script>
     <script>
       _linkedin_data_partner_id = "42871";
     </script>
     <script>
-      (function(){var s = document.getElementsByTagName("script")[0];var b = document.createElement("script");b.type = "text/javascript";b.async = true;b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";s.parentNode.insertBefore(b, s);})();
+      (function () {
+        var s = document.getElementsByTagName("script")[0];
+        var b = document.createElement("script");
+        b.type = "text/javascript";
+        b.async = true;
+        b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+        s.parentNode.insertBefore(b, s);
+      })();
     </script>
     <!-- Facebook Pixel Code -->
     <script>
-    !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');fbq('init', '1585683128395225');fbq('track', 'PageView');
+      !(function (f, b, e, v, n, t, s) {
+        if (f.fbq) return;
+        n = f.fbq = function () {
+          n.callMethod
+            ? n.callMethod.apply(n, arguments)
+            : n.queue.push(arguments);
+        };
+        if (!f._fbq) f._fbq = n;
+        n.push = n;
+        n.loaded = !0;
+        n.version = "2.0";
+        n.queue = [];
+        t = b.createElement(e);
+        t.async = !0;
+        t.src = v;
+        s = b.getElementsByTagName(e)[0];
+        s.parentNode.insertBefore(t, s);
+      })(
+        window,
+        document,
+        "script",
+        "https://connect.facebook.net/en_US/fbevents.js"
+      );
+      fbq("init", "1585683128395225");
+      fbq("track", "PageView");
     </script>
     <noscript>
-      <img height="1" width="1" src="https://www.facebook.com/tr?id=1585683128395225&ev=PageView&noscript=1"/>
+      <img
+        height="1"
+        width="1"
+        src="https://www.facebook.com/tr?id=1585683128395225&ev=PageView&noscript=1"
+      />
     </noscript>
     <!-- End Facebook Pixel Code -->
   </head>
@@ -43,59 +124,196 @@
     <nav class="nav-bar banner-visible">
       <div class="nav-bar-inner">
         <a href="{{ url_for('render_home_page') }}" class="img-link">
-          <img src="{{ url_for('static', filename='img/techtonica_logo.png') }}" alt="Techtonica" class="logo">
+          <img
+            src="{{ url_for('static', filename='img/techtonica_logo.png') }}"
+            alt="Techtonica"
+            class="logo"
+          />
         </a>
-        <button class="lines-button hidden-lg" type="button" aria-label="Toggle Navigation">
+        <button
+          class="lines-button hidden-lg"
+          type="button"
+          aria-label="Toggle Navigation"
+        >
           <span class="lines"></span>
         </button>
-          <a href="{{ url_for('render_donate_page') }}" class="nav-link">Donate</a>
-          <a href="{{ url_for('render_openings_page') }}" class="nav-link">Openings</a>
-          <a href="{{ url_for('render_team_page') }}" class="nav-link">Team</a>
-          <a href="{{ url_for('render_faqs_page') }}" class="nav-link">FAQs</a>
-          <a href="{{ url_for('render_volunteer_page') }}" class="nav-link">Volunteer</a>
-          <a href="{{ url_for('render_sponsor_page') }}" class="nav-link">Sponsor</a>
-  <!--         <a href="{{ url_for('render_home_page') }}#supporters" class="supporters nav-link">Supporters</a> -->
-<!--           <a href="{{ url_for('render_volunteer_page') }}" class="nav-link">Volunteer</a> -->
+        <a href="{{ url_for('render_donate_page') }}" class="nav-link"
+          >Donate</a
+        >
+        <a href="{{ url_for('render_openings_page') }}" class="nav-link"
+          >Openings</a
+        >
+        <a href="{{ url_for('render_team_page') }}" class="nav-link">Team</a>
+        <a href="{{ url_for('render_faqs_page') }}" class="nav-link">FAQs</a>
+        <a href="{{ url_for('render_volunteer_page') }}" class="nav-link"
+          >Volunteer</a
+        >
+        <a href="{{ url_for('render_sponsor_page') }}" class="nav-link"
+          >Sponsor</a
+        >
+        <!--         <a href="{{ url_for('render_home_page') }}#supporters" class="supporters nav-link">Supporters</a> -->
+        <!--           <a href="{{ url_for('render_volunteer_page') }}" class="nav-link">Volunteer</a> -->
       </div>
     </nav>
     <!-- BEGIN MAIN CONTENT -->
     <div class="main-content">
-      {% block content %}
-      {% endblock content %}
+      {% block content %} {% endblock content %}
     </div>
     <!-- BEGIN FOOTER -->
     <div class="row row__center gray-background">
       <div class="column">
         <p class="centered">
-          <a href="https://twitter.com/TechtonicaOrg" target="_blank" rel="noopener noreferrer" title="Twitter"><img src="{{ url_for('static', filename='img/twitter-blue.png') }}" class="social-media" alt="Techtonica Twitter"></a>
-          <a href="https://www.linkedin.com/company/techtonica/" target="_blank" rel="noopener noreferrer" title="LinkedIn"><img src="{{ url_for('static', filename='img/linkedin-blue.png') }}" class="social-media" alt="Techtonica LinkedIn"></a>
-          <a href="https://www.facebook.com/Techtonica/" target="_blank" rel="noopener noreferrer" title="Facebook"><img src="{{ url_for('static', filename='img/facebook-blue.png') }}" class="social-media" alt="Techtonica Facebook"></a>
-          <a href="https://www.instagram.com/TechtonicaOrg/" target="_blank" rel="noopener noreferrer" title="Instagram"><img src="{{ url_for('static', filename='img/instagram-icon.png') }}" class="social-media" alt="Techtonica Instagram"></a>
-          <a href="https://medium.com/techtonica/" target="_blank" rel="noopener noreferrer" title="Medium"><img src="{{ url_for('static', filename='img/medium.png') }}" class="social-media" alt="Techtonica Medium Publication"></a>
-          <a href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg" target="_blank" rel="noopener noreferrer" title="YouTube"><img src="{{ url_for('static', filename='img/youtube.png') }}" class="social-media" alt="Techtonica YouTube"></a>
-          <a href="{{ url_for('render_conduct_page') }}" title="Code of Conduct"><img src="{{ url_for('static', filename='img/code-of-conduct-blue.jpg') }}" class="social-media" alt="Techtonica Code of Conduct"></a>
-          <a href="{{ url_for('render_faqs_page') }}" title="FAQs"><img src="{{ url_for('static', filename='img/faqs-icon.png') }}" class="social-media" alt="Techtonica FAQs"></a>
-          <a href="mailto:info@techtonica.org" title="Email"><img src="{{ url_for('static', filename='img/mail-icon.png') }}" class="social-media" alt="Techtonica Email"></a>
-          <a href="https://www.eventbrite.com/o/techtonica-11297022451" title="Events"><img src="{{ url_for('static', filename='img/calendar-icon.png') }}" class="social-media" alt="Techtonica Events"></a>
-          <a href="{{ url_for('render_news_page') }}" title="News"><img src="{{ url_for('static', filename='img/news-icon.png') }}" class="social-media" alt="Techtonica News"></a>
-          <a href="{{ url_for('render_openings_page') }}" title="Openings"><img src="{{ url_for('static', filename='img/we-are-hiring.png') }}" class="hiring" alt="Techtonica Careers"></a>
-       </p>
-        <p class="centered">All content &copy; Techtonica, a fiscally-sponsored project of <a href="http://www.socialgoodfund.org" target="_blank" rel="noopener noreferrer">SocialGood</a> (Nonprofit EIN: 46-1323531)</p>
+          <a
+            href="https://twitter.com/TechtonicaOrg"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Twitter"
+            ><img
+              src="{{ url_for('static', filename='img/twitter-blue.png') }}"
+              class="social-media"
+              alt="Techtonica Twitter"
+          /></a>
+          <a
+            href="https://www.linkedin.com/company/techtonica/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="LinkedIn"
+            ><img
+              src="{{ url_for('static', filename='img/linkedin-blue.png') }}"
+              class="social-media"
+              alt="Techtonica LinkedIn"
+          /></a>
+          <a
+            href="https://www.facebook.com/Techtonica/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Facebook"
+            ><img
+              src="{{ url_for('static', filename='img/facebook-blue.png') }}"
+              class="social-media"
+              alt="Techtonica Facebook"
+          /></a>
+          <a
+            href="https://www.instagram.com/TechtonicaOrg/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Instagram"
+            ><img
+              src="{{ url_for('static', filename='img/instagram-icon.png') }}"
+              class="social-media"
+              alt="Techtonica Instagram"
+          /></a>
+          <a
+            href="https://medium.com/techtonica/"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Medium"
+            ><img
+              src="{{ url_for('static', filename='img/medium.png') }}"
+              class="social-media"
+              alt="Techtonica Medium Publication"
+          /></a>
+          <a
+            href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="YouTube"
+            ><img
+              src="{{ url_for('static', filename='img/youtube.png') }}"
+              class="social-media"
+              alt="Techtonica YouTube"
+          /></a>
+          <a href="{{ url_for('render_conduct_page') }}" title="Code of Conduct"
+            ><img
+              src="{{ url_for('static', filename='img/code-of-conduct-blue.jpg') }}"
+              class="social-media"
+              alt="Techtonica Code of Conduct"
+          /></a>
+          <a href="{{ url_for('render_faqs_page') }}" title="FAQs"
+            ><img
+              src="{{ url_for('static', filename='img/faqs-icon.png') }}"
+              class="social-media"
+              alt="Techtonica FAQs"
+          /></a>
+          <a href="mailto:info@techtonica.org" title="Email"
+            ><img
+              src="{{ url_for('static', filename='img/mail-icon.png') }}"
+              class="social-media"
+              alt="Techtonica Email"
+          /></a>
+          <a
+            href="https://www.eventbrite.com/o/techtonica-11297022451"
+            title="Events"
+            ><img
+              src="{{ url_for('static', filename='img/calendar-icon.png') }}"
+              class="social-media"
+              alt="Techtonica Events"
+          /></a>
+          <a href="{{ url_for('render_news_page') }}" title="News"
+            ><img
+              src="{{ url_for('static', filename='img/news-icon.png') }}"
+              class="social-media"
+              alt="Techtonica News"
+          /></a>
+          <a href="{{ url_for('render_openings_page') }}" title="Openings"
+            ><img
+              src="{{ url_for('static', filename='img/we-are-hiring.png') }}"
+              class="hiring"
+              alt="Techtonica Careers"
+          /></a>
+        </p>
+        <p class="centered">
+          All content &copy; Techtonica, a fiscally-sponsored project of
+          <a
+            href="http://www.socialgoodfund.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            >SocialGood</a
+          >
+          (Nonprofit EIN: 46-1323531)
+        </p>
       </div>
     </div>
 
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
-    <link href='https://fonts.googleapis.com/css?family=Lato:400,700' rel='stylesheet' type='text/css'>
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css?family=Lato:400,700"
+      rel="stylesheet"
+      type="text/css"
+    />
 
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js" integrity="sha256-BJeo0qm959uMBGb65z40ejJYGSgR7REI4+CW1fNKwOg=" crossorigin="anonymous"></script>
+    <script
+      src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.0/jquery.min.js"
+      integrity="sha256-BJeo0qm959uMBGb65z40ejJYGSgR7REI4+CW1fNKwOg="
+      crossorigin="anonymous"
+    ></script>
     {% block popup %}
-      <script defer src="{{ url_for('static', filename='js/index.js') }}"></script>
+    <script
+      defer
+      src="{{ url_for('static', filename='js/index.js') }}"
+    ></script>
     {% endblock %}
-    <script defer src="{{ url_for('static', filename='js/scroll.js') }}"></script>
-    <script defer src="{{ url_for('static', filename='js/collapsible.js') }}"></script>
-    <script defer src="https://s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js" data-dojo-config="usePlainJson: true, isDebug: false"></script>
+    <script
+      defer
+      src="{{ url_for('static', filename='js/scroll.js') }}"
+    ></script>
+    <script
+      defer
+      src="{{ url_for('static', filename='js/collapsible.js') }}"
+    ></script>
+    <script
+      defer
+      src="https://s3.amazonaws.com/downloads.mailchimp.com/js/signup-forms/popup/embed.js"
+      data-dojo-config="usePlainJson: true, isDebug: false"
+    ></script>
     <!-- Start of HubSpot Embed Code -->
-    <script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/6032726.js"></script>
+    <script
+      type="text/javascript"
+      id="hs-script-loader"
+      async
+      defer
+      src="//js.hs-scripts.com/6032726.js"
+    ></script>
     <!-- End of HubSpot Embed Code -->
   </body>
 </html>

--- a/templates/board.html
+++ b/templates/board.html
@@ -1,52 +1,101 @@
-{% extends "base.html" %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%;"
+    />
+  </div>
+  <div class="column">
+    <h1 class="blue-h1">Openings</h1>
+    <p class="justify">
+      Techtonica is a nonprofit that offers women and non-binary adults with low
+      incomes free tech training, along with living and childcare stipends, then
+      places them in positions at sponsoring companies that are ready to support
+      more diverse teams. You can
+      <a
+        href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc"
+        >read more here</a
+      >.
+    </p>
+    <div>
+      <h3>Make an Impact as a Board Member!</h3>
+      <p>
+        If you are an experienced leader who cares deeply about compassionately
+        empowering local neighbors with low incomes, join us! We are especially
+        seeking seasoned, well-connected board members who are passionate about
+        diversity and inclusion and social justice, who are strong fundraisers
+        and marketers, who are in the San Francisco Bay Area, and who can relate
+        to the people we serve on multiple levels: 75%+ of our participants are
+        people of color, and all of them are local women or non-binary adults
+        with low incomes.
+      </p>
 
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Careers
-{% endblock title %}
-
-{% block content %}
-  <div class="row row__center about-us">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
-           alt="A mentor works with a participant at a laptop." 
-           class="fixed-img" style="width:38%;">
+      <h3>You are willing and able to:</h3>
+      <ul>
+        <li>
+          Regularly make time to attend and prepare for meetings—we currently
+          have a board meeting the first Monday evening of each month and a
+          committee check-in on the third Monday evening of each month. Be
+          involved in the topics when you miss meetings.
+        </li>
+        <li>
+          Answer emails within two days and be available to give opinions on
+          matters that pop up via Slack or text.
+        </li>
+        <li>
+          Determine and be informed about Techtonica’s mission, services,
+          policies, programs, and events.
+        </li>
+        <li>Make decisions efficiently and be open to others’ ideas.</li>
+        <li>Communicate clearly and respectfully.</li>
+        <li>Participate in fundraising.</li>
+        <li>Attend one workshop per year.</li>
+        <li>Speak to participants once per year.</li>
+        <li>Help organize one event per year.</li>
+        <li>
+          Commit at least one new large
+          <a href="http://techtonica.org/sponsor">sponsor</a> per year.
+        </li>
+        <li>
+          Donate (or find someone to donate) at least $1,750 per year, starting
+          with your first month.
+        </li>
+        <li>Build partnerships with 2 community orgs per year.</li>
+        <li>Lead or participate in organizational committees.</li>
+        <li>Be a Techtonica ambassador at events, speaking gigs, etc.</li>
+        <li>Act at all times for the benefit of Techtonica and its purpose.</li>
+        <li>
+          Disclose possible conflicts of interest, abstain from voting when a
+          conflict may exist, and avoid self-dealing activities.
+        </li>
+        <li>
+          Seek outside help such as lawyers, accountants, and other professional
+          services as needed by Techtonica.
+        </li>
+        <li>
+          Ensure up-to-date personnel policies, complies with employment laws,
+          and follows these policies and laws.
+        </li>
+        <li>Consult or advise staff in your area of expertise.</li>
+        <li>Providing thought partnership to the CEO and staff.</li>
+        <li>
+          Use modern, online tech tools such as Google Drive and Google Calendar
+          to manage organizational needs.
+        </li>
+      </ul>
+      <p>
+        If this sounds like a good role for you, please contact us with your
+        LinkedIn profile and a little bit about how you relate to the target
+        audience.
+      </p>
     </div>
-    <div class="column">
-      <h1 class="blue-h1">Openings</h1>
-      <p class="justify">Techtonica is a nonprofit that offers women and non-binary adults with low incomes free tech training, along with living and childcare stipends, then places them in positions at sponsoring companies that are ready to support more diverse teams. You can <a href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc">read more here</a>.</p>
-      <div>
-        <h3>Make an Impact as a Board Member!</h3>
-        <p>If you are an experienced leader who cares deeply about compassionately empowering local neighbors with low incomes, join us! We are especially seeking seasoned, well-connected board members who are passionate about diversity and inclusion and social justice, who are strong fundraisers and marketers, who are in the San Francisco Bay Area, and who can relate to the people we serve on multiple levels: 75%+ of our participants are people of color, and all of them are local women or non-binary adults with low incomes.</p>
-
-        <h3>You are willing and able to:</h3>
-        <ul>
-          <li>Regularly make time to attend and prepare for meetings—we currently have a board meeting the first Monday evening of each month and a committee check-in on the third Monday evening of each month. Be involved in the topics when you miss meetings.</li>
-          <li>Answer emails within two days and be available to give opinions on matters that pop up via Slack or text.</li>
-          <li>Determine and be informed about Techtonica’s mission, services, policies, programs, and events.</li>
-          <li>Make decisions efficiently and be open to others’ ideas.</li>
-          <li>Communicate clearly and respectfully.</li>
-          <li>Participate in fundraising.</li>
-          <li>Attend one workshop per year.</li>
-          <li>Speak to participants once per year.</li>
-          <li>Help organize one event per year.</li>
-          <li>Commit at least one new large <a href="http://techtonica.org/sponsor">sponsor</a> per year.</li>
-          <li>Donate (or find someone to donate) at least $1,750 per year, starting with your first month.</li>
-          <li>Build partnerships with 2 community orgs per year.</li>
-          <li>Lead or participate in organizational committees.</li>
-          <li>Be a Techtonica ambassador at events, speaking gigs, etc.</li>
-          <li>Act at all times for the benefit of Techtonica and its purpose.</li>
-          <li>Disclose possible conflicts of interest, abstain from voting when a conflict may exist, and avoid self-dealing activities.</li>
-          <li>Seek outside help such as lawyers, accountants, and other professional services as needed by Techtonica.</li>
-          <li>Ensure up-to-date personnel policies, complies with employment laws, and follows these policies and laws.</li>
-          <li>Consult or advise staff in your area of expertise.</li>
-          <li>Providing thought partnership to the CEO and staff.</li>
-          <li>Use modern, online tech tools such as Google Drive and Google Calendar to manage organizational needs.</li>
-        </ul>
-        <p>If this sounds like a good role for you, please contact us with your LinkedIn profile and a little bit about how you relate to the target audience.</p>
-      </div>
-      <div>
-        {% include 'contactbutton.html' %}
-      </div>
+    <div>
+      {% include 'contactbutton.html' %}
     </div>
   </div>
+</div>
 {% endblock content %}

--- a/templates/conduct.html
+++ b/templates/conduct.html
@@ -1,224 +1,523 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Code of Conduct
-{% endblock title %}
-
-{% block content %}
-  <div class="main-content">
-      <div class="main-header">
-        <div class="main-header__text blue-background">
-          <h1>Techtonica Mission and Code of Conduct</h1>
-        </div>
-      </div>
-      <div class="row row__center mission" id="mission">
-        <div class="column">
-          <h1 class="blue-h1">Mission</h1>
-          <p class="justify">Techtonica’s mission is to make every engineering team as diverse as its local community while empowering women and non-binary adults with low incomes through tech training and careers.</p>
-        </div>
-      </div>
-      <div class="row row__center blue-background short-form-conduct" id="shortformconduct">
-        <div class="column">
-          <h1>Short Form Code of Conduct</h1>
-          <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form and we prioritize marginalized people’s safety over privileged people’s comfort. [If quoting this, include a link to this document: Our full Code of Conduct can be found at this <a href="{{ url_for('render_conduct_page') }}">link</a>.]</p>
-        </div>
-      </div>
-      <div class="row row__center long-form-conduct" id="longformconduct">
-        <div class="column">
-          <h1 class="blue-h1">Long Form Code of Conduct</h1>
-          <p class="justify">Techtonica is dedicated to providing a safe, inclusive, welcoming, and harassment-free space and experience for all members and guests, regardless of gender identity and expression, sexual orientation, disability, physical appearance, socioeconomic status, body size, ethnicity, nationality, level of experience, age, or religion (or lack thereof). Our Code of Conduct exists because of that dedication. We do not tolerate harassment in any form.</p>
-          <p>This Code of Conduct applies to all Techtonica spaces, Techtonica events (for both members and their guests), and communities, online and off, as well as in one-on-one communications pertaining to Techtonica business. Members violating our Code of Conduct may be penalized or expelled at the discretion of community moderators.</p>
-          <p>Some Techtonica spaces (such as specific Slack channels) may have additional rules in place, which are posted publicly for participants. Participants are responsible for knowing and abiding by these rules. We invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
-          <p>Consequences for noncompliance with the Code of Conduct may include a discussion with mediators, mediation with the member you may have harmed, or as an absolute last resort, a ban from the community.</p>
-            <h3>Behavior</h3>
-            <p class="justify">Harassment includes:
-              <ul>
-                <li>Discriminatory language and actions that reinforce social structures of domination related to gender, gender identity and expression, sexual orientation, disability, mental illness, neuro(a)typicality, physical appearance, body size, age, race, or religion</li>
-                <li>Trolling, insults, or personal attacks</li>
-                <li>Violent or personally objectifying material</li>
-                <li>Gratuitous or off-topic sexual images or behavior in spaces where they’re not appropriate</li>
-                <li>Unwelcome sexual attention</li>
-                <li>Physical contact and simulated physical contact (e.g., textual descriptions like “backrub”) without consent or after a request to stop</li>
-                <li>Violent language or threats of violence</li>
-                <li>Incitement of violence towards any individual, including encouraging a person to commit suicide or to engage in self-harm</li>
-                <li>Unwelcome comments regarding a person’s lifestyle choices and practices, including those related to food, health, parenting, drugs, and employment</li>
-                <li>Deliberate misgendering or use of “dead” or rejected names</li>
-                <li>Pattern of inappropriate social contact, such as requesting/assuming unprofessional levels of intimacy with others</li>
-                <li>Continued one-on-one communication after requests to cease</li>
-                <li>Deliberate “outing” of any aspect of a person’s identity without their consent</li>
-                <li>Threatening to post or posting other people’s personally identifiable information without consent</li>
-                <li>Publication of non-harassing private communication without consent</li>
-                <li>Blogging, tweeting, or otherwise communicating with intent to harm someone’s reputation, i.e., “making an example” of a member</li>
-                <li>Intimidation, stalking, or following</li>
-                <li>Harassing or unwanted photography or recording, including logging online activity for harassment purposes</li>
-                <li>Sustained, uninvited disruption</li>
-                <li>Other conduct which could reasonably be considered inappropriate in a professional setting</li>
-                <li>Recruiting or trying to recruit participants of Techtonica's programs outside of formal sponsorship agreements</li>
-                <li>Advocating for, or encouraging, any of the above behavior</li>  
-              </ul>
-           </p>
-            <p class="justify">Techtonica prioritizes marginalized people’s safety over privileged people’s comfort. Our moderators will not act on complaints regarding: 
-              <ul>
-                <li>“Reverse”-isms, including “reverse racism,” “reverse sexism,” and “cisphobia.”</li>
-                <li>Reasonable communication of boundaries, such as “leave me alone,” “go away,” or “I’m not discussing this with you.”</li>
-                <li>Verbal communication in a tone you don’t find pleasant (try focusing on responding to the content or disengaging instead)</li>
-                <li>Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions</li>
-              </ul>
-           </p>
-            <p class="justify">Appropriate behavior contributes to the health, safety, and longevity of the Techtonica community and includes:
-              <ul>
-                <li>Participating authentically and empathetically</li>
-                <li>Representing Techtonica in a positive, professional way</li>
-                <li>Examining your biases often</li>
-                <li>Using welcoming and inclusive language</li>
-                <li>Exercising consideration and respect in your speech and actions</li>
-                <li>Refraining from demeaning, discriminatory, or harassing behavior and speech</li>
-                <li>Being mindful of your surroundings and of your fellow participants</li>
-                <li>Considering what is best for the community</li>
-                <li>Alerting community moderators if you notice a dangerous situation, someone in distress, or unresolved violations of this Code of Conduct</li>
-                <li>Refraining from doing something you wouldn’t do in another professional situation</li>
-                <li>Remembering that community event venues may be shared with members of the public; being respectful to all patrons of these locations</li>
-                <li>Keeping an open and curious mind without making assumptions about others</li>
-                <li>Attempting collaboration before conflict (see communication tools below).
-Gracefully accepting constructive criticism</li>
-              </ul>
-           </p>
-            <h3>Enforcement</h3>
-            <p class="justify">
-              <ul>
-                <li>Members and participating guests asked to stop any harassing behavior are expected to comply immediately</li>
-                <li>If a participant violates the Code of Conduct, community moderators may take any action they deem appropriate to maintaining a welcoming environment for all participants, up to and including expulsion from an event and/or the community and identification of the participant as a violator</li>
-                <li>If a community moderator is not present at an event, the event organizer should ask violators to leave and then report the situation to community moderators for further deliberation</li>
-                <li>Community moderators and/or event organizers may take action to redress anything designed to, or with the clear impact of, disrupting or making an environment hostile for any participants</li>
-                <li>We expect participants to respect the Code of Conduct in all Techtonica communities and at all Techtonica or Techtonica-related events</li>
-              </ul>
-            </p>
-            <h3>Reporting</h3>
-            <p class="justify">If you experience or witness (or have experienced or have witnessed) violations of the Code of Conduct or have any other concerns, please notify a Techtonica staff member or <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">submit an online report here</a>. 
-            </p>
-            <p class="justify">Code of Conduct violations can be reported by:
-              <ul>
-                <li>Emailing info@techtonica.org</li>
-                <li>Contacting a staff member privately on via email, by text or phone call, or in person</li>
-                <li>Communicating with the event organizer (if you’re at an event—all events must come with contact information for an organizer)</li>
-                <li>Anonymous reports can also be made by filling out this <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">form</a></li>
-              </ul>
-            </p>
-            <p class="justify">Reports of Code of Conduct violations should include as many details as possible, for example:
-              <ul>
-                <li>Contact info for the reporter (unless anonymous)</li>
-                <li>Names or descriptions of people involved</li>
-                <li>When and where it happened</li>
-                <li>What happened</li>
-                <li>Additional context</li>
-                <li>If the problem is ongoing</li>
-              </ul>
-            </p>
-            <h3>Apologizing</h3>
-            <p class="justify">Everyone does hurtful things at times. What's important is that you:
-              <ul>
-                <li>Listen</li>
-                <li>Show your gratitude for feedback</li>
-                <li>Focus on the impact instead of your behavior and intention</li>
-                <li>Apologize</li>
-                <li>Commit to doing better</li>
-                <li>Learn from the experience</li>
-              </ul>
-            </p>
-            <h3>Moderators</h3>
-            <p class="justify">Moderators will:
-              <ul>
-                <li>Work together to respond to violations</li>
-                <li>Respond as promptly as possible to reports of violations</li>
-                <li>Make an effort to understand both sides of the situation, including talking to affected members and reading up on the underlying issues, particularly if they don’t have similar personal experience(s)</li>
-                <li>Keep each other accountable</li>
-                <li>Trade off duties when needed</li>
-              </ul>
-            </p>
-            <p class="justify">Please see the Techtonica organization documents to learn more about moderators.</p>
-            <h3>Additional Items</h3>
-            <p class="justify">Please also note:
-              <ul>
-                <li>If the person violating the Code of Conduct is a moderator, they will recuse themselves or be excused from handling the incident</li>
-                <li>Members are responsible for guests. If a guest's behavior violates the Code of Conduct, they could be asked to leave, and could be disallowed from participating in future Techtonica events</li>
-                <li>Moderators can choose to close threads or ask for a subject change</li>
-                <li>Moderators can choose to re-evaluate consequences</li>
-                <li>Do not delete posts or comments you’ve made unless:
-                  <ul>
-                    <li>You sincerely made the post in error (like accidentally posting in the wrong group, for example) and</li>
-                    <li>Deleting will not interfere with group discussion. Deleting because the conversation has become tense or uncomfortable or to avoid taking responsibility is the specific problem we want to address with this rule; many of us are socialized or naturally prone to avoid conflict, but working through that conflict and acknowledging differing viewpoints is worth the discomfort</li>
-                  </ul>
-               </li>
-                <li>This Code of Conduct applies to Techtonica spaces and events, but if you are being or have been harassed by a Techtonica member externally, you may still report to the Techtonica moderators. We will take all good-faith reports of harassment by Techtonica members seriously. The Techtonica moderators reserve the right to exclude people from the Techtonica community and/or Techtonica events based on past and/or external behavior towards Techtonica members or non-members</li>
-                <li>Techtonica moderators may reject any report believed to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response</li>
-                <li>We will not name harassment victims without their consent. At our discretion, we may publicly name a person about whom we’ve received harassment complaints, or privately warn third parties about them, if we believe that doing so will increase the safety of Techtonica members or the general public</li>
-                <li>Reports can be made at any time, but as soon as possible is preferred</li>
-                <li>Our promise: When taking a private report, our community moderators will ensure you are safe and cannot be overheard. They may involve other moderators to ensure your report is managed properly. Once safe, we'll ask you to tell us about what happened. This can be upsetting, but we'll handle it as respectfully as possible, and you can bring someone to support you. You won't be asked to confront anyone and we won't tell anyone who you are. Our team will be happy to help you contact venue security, local law enforcement, local support services, provide escorts, or otherwise assist you to feel safe. We value your participation</li>
-              </ul>
-            </p>
-            <p class="justify">Once again, we invite all those who participate in Techtonica to help us create safe and positive community experiences.</p>
-            <h3>Sources</h3>
-            <p class="justify">
-            <ul>
-              <li><a href="www.ladynerds.org/code_of_conduct/">“LadyNerds Code of Conduct”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">“Conference anti-harassment/Policy”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy">“Community anti-harassment/Policy”</a></li>
-              <li><a href="http://www.slideshare.net/aeschright/enforcing-your-code-of-conduct-effective-incident-response">“HOWTO design a code of conduct for your community”</a></li>
-              <li><a href="http://geekfeminism.wikia.com/wiki/Code_of_conduct ">“Code of conduct evaluations”</a></li>
-              <li><a href="http://citizencodeofconduct.org/">“Citizen Code of Conduct”</a></li>
-              <li><a href="http://witchat.github.io/">“WITchat Community Code of Conduct”</a></li>
-              <li><a href="http://contributor-covenant.org/">“Contributor Covenant Code of Conduct”</a></li>
-              <li><a href="https://docs.google.com/document/d/19SqO1kRp7yLXnzZvw1UgSViIh9iVy4KQndgcdHCZHoY/edit?usp=sharing">“Old LadyNerds Code of Conduct”</a></li>
-              <li><a href="http://code-of-conduct.voxmedia.com/">Vox Media’s “Code of Conduct”</a></li>
-            </ul>
-           </p>
-      <div class="row row__center blue-background short-form-conduct" id="shortformconduct">
-<!--         <div class="column">
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Code of Conduct {% endblock title %} {% block content %}
+<div class="main-content">
+  <div class="main-header">
+    <div class="main-header__text blue-background">
+      <h1>Techtonica Mission and Code of Conduct</h1>
+    </div>
+  </div>
+  <div class="row row__center mission" id="mission">
+    <div class="column">
+      <h1 class="blue-h1">Mission</h1>
+      <p class="justify">
+        Techtonica’s mission is to make every engineering team as diverse as its
+        local community while empowering women and non-binary adults with low
+        incomes through tech training and careers.
+      </p>
+    </div>
+  </div>
+  <div
+    class="row row__center blue-background short-form-conduct"
+    id="shortformconduct"
+  >
+    <div class="column">
+      <h1>Short Form Code of Conduct</h1>
+      <p class="justify">
+        Techtonica is dedicated to providing a safe, inclusive, welcoming, and
+        harassment-free space and experience for all members and guests,
+        regardless of gender identity and expression, sexual orientation,
+        disability, physical appearance, socioeconomic status, body size,
+        ethnicity, nationality, level of experience, age, or religion (or lack
+        thereof). Our Code of Conduct exists because of that dedication. We do
+        not tolerate harassment in any form and we prioritize marginalized
+        people’s safety over privileged people’s comfort. [If quoting this,
+        include a link to this document: Our full Code of Conduct can be found
+        at this <a href="{{ url_for('render_conduct_page') }}">link</a>.]
+      </p>
+    </div>
+  </div>
+  <div class="row row__center long-form-conduct" id="longformconduct">
+    <div class="column">
+      <h1 class="blue-h1">Long Form Code of Conduct</h1>
+      <p class="justify">
+        Techtonica is dedicated to providing a safe, inclusive, welcoming, and
+        harassment-free space and experience for all members and guests,
+        regardless of gender identity and expression, sexual orientation,
+        disability, physical appearance, socioeconomic status, body size,
+        ethnicity, nationality, level of experience, age, or religion (or lack
+        thereof). Our Code of Conduct exists because of that dedication. We do
+        not tolerate harassment in any form.
+      </p>
+      <p>
+        This Code of Conduct applies to all Techtonica spaces, Techtonica events
+        (for both members and their guests), and communities, online and off, as
+        well as in one-on-one communications pertaining to Techtonica business.
+        Members violating our Code of Conduct may be penalized or expelled at
+        the discretion of community moderators.
+      </p>
+      <p>
+        Some Techtonica spaces (such as specific Slack channels) may have
+        additional rules in place, which are posted publicly for participants.
+        Participants are responsible for knowing and abiding by these rules. We
+        invite all those who participate in Techtonica to help us create safe
+        and positive community experiences.
+      </p>
+      <p>
+        Consequences for noncompliance with the Code of Conduct may include a
+        discussion with mediators, mediation with the member you may have
+        harmed, or as an absolute last resort, a ban from the community.
+      </p>
+      <h3>Behavior</h3>
+      <p class="justify">Harassment includes:</p>
+      <ul>
+        <li>
+          Discriminatory language and actions that reinforce social structures
+          of domination related to gender, gender identity and expression,
+          sexual orientation, disability, mental illness, neuro(a)typicality,
+          physical appearance, body size, age, race, or religion
+        </li>
+        <li>Trolling, insults, or personal attacks</li>
+        <li>Violent or personally objectifying material</li>
+        <li>
+          Gratuitous or off-topic sexual images or behavior in spaces where
+          they’re not appropriate
+        </li>
+        <li>Unwelcome sexual attention</li>
+        <li>
+          Physical contact and simulated physical contact (e.g., textual
+          descriptions like “backrub”) without consent or after a request to
+          stop
+        </li>
+        <li>Violent language or threats of violence</li>
+        <li>
+          Incitement of violence towards any individual, including encouraging a
+          person to commit suicide or to engage in self-harm
+        </li>
+        <li>
+          Unwelcome comments regarding a person’s lifestyle choices and
+          practices, including those related to food, health, parenting, drugs,
+          and employment
+        </li>
+        <li>Deliberate misgendering or use of “dead” or rejected names</li>
+        <li>
+          Pattern of inappropriate social contact, such as requesting/assuming
+          unprofessional levels of intimacy with others
+        </li>
+        <li>Continued one-on-one communication after requests to cease</li>
+        <li>
+          Deliberate “outing” of any aspect of a person’s identity without their
+          consent
+        </li>
+        <li>
+          Threatening to post or posting other people’s personally identifiable
+          information without consent
+        </li>
+        <li>
+          Publication of non-harassing private communication without consent
+        </li>
+        <li>
+          Blogging, tweeting, or otherwise communicating with intent to harm
+          someone’s reputation, i.e., “making an example” of a member
+        </li>
+        <li>Intimidation, stalking, or following</li>
+        <li>
+          Harassing or unwanted photography or recording, including logging
+          online activity for harassment purposes
+        </li>
+        <li>Sustained, uninvited disruption</li>
+        <li>
+          Other conduct which could reasonably be considered inappropriate in a
+          professional setting
+        </li>
+        <li>
+          Recruiting or trying to recruit participants of Techtonica's programs
+          outside of formal sponsorship agreements
+        </li>
+        <li>Advocating for, or encouraging, any of the above behavior</li>
+      </ul>
+      <p class="justify">
+        Techtonica prioritizes marginalized people’s safety over privileged
+        people’s comfort. Our moderators will not act on complaints regarding:
+      </p>
+      <ul>
+        <li>
+          “Reverse”-isms, including “reverse racism,” “reverse sexism,” and
+          “cisphobia.”
+        </li>
+        <li>
+          Reasonable communication of boundaries, such as “leave me alone,” “go
+          away,” or “I’m not discussing this with you.”
+        </li>
+        <li>
+          Verbal communication in a tone you don’t find pleasant (try focusing
+          on responding to the content or disengaging instead)
+        </li>
+        <li>
+          Criticizing racist, sexist, cissexist, or otherwise oppressive
+          behavior or assumptions
+        </li>
+      </ul>
+      <p class="justify">
+        Appropriate behavior contributes to the health, safety, and longevity of
+        the Techtonica community and includes:
+      </p>
+      <ul>
+        <li>Participating authentically and empathetically</li>
+        <li>Representing Techtonica in a positive, professional way</li>
+        <li>Examining your biases often</li>
+        <li>Using welcoming and inclusive language</li>
+        <li>Exercising consideration and respect in your speech and actions</li>
+        <li>
+          Refraining from demeaning, discriminatory, or harassing behavior and
+          speech
+        </li>
+        <li>
+          Being mindful of your surroundings and of your fellow participants
+        </li>
+        <li>Considering what is best for the community</li>
+        <li>
+          Alerting community moderators if you notice a dangerous situation,
+          someone in distress, or unresolved violations of this Code of Conduct
+        </li>
+        <li>
+          Refraining from doing something you wouldn’t do in another
+          professional situation
+        </li>
+        <li>
+          Remembering that community event venues may be shared with members of
+          the public; being respectful to all patrons of these locations
+        </li>
+        <li>
+          Keeping an open and curious mind without making assumptions about
+          others
+        </li>
+        <li>
+          Attempting collaboration before conflict (see communication tools
+          below). Gracefully accepting constructive criticism
+        </li>
+      </ul>
+      <h3>Enforcement</h3>
+      <ul>
+        <li>
+          Members and participating guests asked to stop any harassing behavior
+          are expected to comply immediately
+        </li>
+        <li>
+          If a participant violates the Code of Conduct, community moderators
+          may take any action they deem appropriate to maintaining a welcoming
+          environment for all participants, up to and including expulsion from
+          an event and/or the community and identification of the participant as
+          a violator
+        </li>
+        <li>
+          If a community moderator is not present at an event, the event
+          organizer should ask violators to leave and then report the situation
+          to community moderators for further deliberation
+        </li>
+        <li>
+          Community moderators and/or event organizers may take action to
+          redress anything designed to, or with the clear impact of, disrupting
+          or making an environment hostile for any participants
+        </li>
+        <li>
+          We expect participants to respect the Code of Conduct in all
+          Techtonica communities and at all Techtonica or Techtonica-related
+          events
+        </li>
+      </ul>
+      <h3>Reporting</h3>
+      <p class="justify">
+        If you experience or witness (or have experienced or have witnessed)
+        violations of the Code of Conduct or have any other concerns, please
+        notify a Techtonica staff member or
+        <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2"
+          >submit an online report here</a
+        >.
+      </p>
+      <p class="justify">Code of Conduct violations can be reported by:</p>
+      <ul>
+        <li>Emailing info@techtonica.org</li>
+        <li>
+          Contacting a staff member privately on via email, by text or phone
+          call, or in person
+        </li>
+        <li>
+          Communicating with the event organizer (if you’re at an event—all
+          events must come with contact information for an organizer)
+        </li>
+        <li>
+          Anonymous reports can also be made by filling out this
+          <a href="https://goo.gl/forms/5gGxKLDgFUTBlmEO2">form</a>
+        </li>
+      </ul>
+      <p class="justify">
+        Reports of Code of Conduct violations should include as many details as
+        possible, for example:
+      </p>
+      <ul>
+        <li>Contact info for the reporter (unless anonymous)</li>
+        <li>Names or descriptions of people involved</li>
+        <li>When and where it happened</li>
+        <li>What happened</li>
+        <li>Additional context</li>
+        <li>If the problem is ongoing</li>
+      </ul>
+      <h3>Apologizing</h3>
+      <p class="justify">
+        Everyone does hurtful things at times. What's important is that you:
+      </p>
+      <ul>
+        <li>Listen</li>
+        <li>Show your gratitude for feedback</li>
+        <li>Focus on the impact instead of your behavior and intention</li>
+        <li>Apologize</li>
+        <li>Commit to doing better</li>
+        <li>Learn from the experience</li>
+      </ul>
+      <h3>Moderators</h3>
+      <p class="justify">Moderators will:</p>
+      <ul>
+        <li>Work together to respond to violations</li>
+        <li>Respond as promptly as possible to reports of violations</li>
+        <li>
+          Make an effort to understand both sides of the situation, including
+          talking to affected members and reading up on the underlying issues,
+          particularly if they don’t have similar personal experience(s)
+        </li>
+        <li>Keep each other accountable</li>
+        <li>Trade off duties when needed</li>
+      </ul>
+      <p class="justify">
+        Please see the Techtonica organization documents to learn more about
+        moderators.
+      </p>
+      <h3>Additional Items</h3>
+      <p class="justify">Please also note:</p>
+      <ul>
+        <li>
+          If the person violating the Code of Conduct is a moderator, they will
+          recuse themselves or be excused from handling the incident
+        </li>
+        <li>
+          Members are responsible for guests. If a guest's behavior violates the
+          Code of Conduct, they could be asked to leave, and could be disallowed
+          from participating in future Techtonica events
+        </li>
+        <li>
+          Moderators can choose to close threads or ask for a subject change
+        </li>
+        <li>Moderators can choose to re-evaluate consequences</li>
+        <li>
+          Do not delete posts or comments you’ve made unless:
+          <ul>
+            <li>
+              You sincerely made the post in error (like accidentally posting in
+              the wrong group, for example) and
+            </li>
+            <li>
+              Deleting will not interfere with group discussion. Deleting
+              because the conversation has become tense or uncomfortable or to
+              avoid taking responsibility is the specific problem we want to
+              address with this rule; many of us are socialized or naturally
+              prone to avoid conflict, but working through that conflict and
+              acknowledging differing viewpoints is worth the discomfort
+            </li>
+          </ul>
+        </li>
+        <li>
+          This Code of Conduct applies to Techtonica spaces and events, but if
+          you are being or have been harassed by a Techtonica member externally,
+          you may still report to the Techtonica moderators. We will take all
+          good-faith reports of harassment by Techtonica members seriously. The
+          Techtonica moderators reserve the right to exclude people from the
+          Techtonica community and/or Techtonica events based on past and/or
+          external behavior towards Techtonica members or non-members
+        </li>
+        <li>
+          Techtonica moderators may reject any report believed to have been made
+          in bad faith. Reports intended to silence legitimate criticism may be
+          deleted without response
+        </li>
+        <li>
+          We will not name harassment victims without their consent. At our
+          discretion, we may publicly name a person about whom we’ve received
+          harassment complaints, or privately warn third parties about them, if
+          we believe that doing so will increase the safety of Techtonica
+          members or the general public
+        </li>
+        <li>
+          Reports can be made at any time, but as soon as possible is preferred
+        </li>
+        <li>
+          Our promise: When taking a private report, our community moderators
+          will ensure you are safe and cannot be overheard. They may involve
+          other moderators to ensure your report is managed properly. Once safe,
+          we'll ask you to tell us about what happened. This can be upsetting,
+          but we'll handle it as respectfully as possible, and you can bring
+          someone to support you. You won't be asked to confront anyone and we
+          won't tell anyone who you are. Our team will be happy to help you
+          contact venue security, local law enforcement, local support services,
+          provide escorts, or otherwise assist you to feel safe. We value your
+          participation
+        </li>
+      </ul>
+      <p class="justify">
+        Once again, we invite all those who participate in Techtonica to help us
+        create safe and positive community experiences.
+      </p>
+      <h3>Sources</h3>
+      <ul>
+        <li>
+          <a href="www.ladynerds.org/code_of_conduct/"
+            >“LadyNerds Code of Conduct”</a
+          >
+        </li>
+        <li>
+          <a
+            href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy"
+            >“Conference anti-harassment/Policy”</a
+          >
+        </li>
+        <li>
+          <a
+            href="http://geekfeminism.wikia.com/wiki/Community_anti-harassment/Policy"
+            >“Community anti-harassment/Policy”</a
+          >
+        </li>
+        <li>
+          <a
+            href="http://www.slideshare.net/aeschright/enforcing-your-code-of-conduct-effective-incident-response"
+            >“HOWTO design a code of conduct for your community”</a
+          >
+        </li>
+        <li>
+          <a href="http://geekfeminism.wikia.com/wiki/Code_of_conduct "
+            >“Code of conduct evaluations”</a
+          >
+        </li>
+        <li>
+          <a href="http://citizencodeofconduct.org/"
+            >“Citizen Code of Conduct”</a
+          >
+        </li>
+        <li>
+          <a href="http://witchat.github.io/"
+            >“WITchat Community Code of Conduct”</a
+          >
+        </li>
+        <li>
+          <a href="http://contributor-covenant.org/"
+            >“Contributor Covenant Code of Conduct”</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://docs.google.com/document/d/19SqO1kRp7yLXnzZvw1UgSViIh9iVy4KQndgcdHCZHoY/edit?usp=sharing"
+            >“Old LadyNerds Code of Conduct”</a
+          >
+        </li>
+        <li>
+          <a href="http://code-of-conduct.voxmedia.com/"
+            >Vox Media’s “Code of Conduct”</a
+          >
+        </li>
+      </ul>
+      <div
+        class="row row__center blue-background short-form-conduct"
+        id="shortformconduct"
+      >
+        <!--         <div class="column">
           <img src="{{ url_for('static', filename='img/tenderloin-sf-min.jpg') }}" alt="tenderloin neighborhood of san francisco" class="full-width-img">
         </div> -->
         <div class="column">
           <h1>Techtonica Communication Tools</h1>
-          <p class="justify">
-            <ul>
-              <li>Don’t hear attack or police tone. Listen for what is behind the words</li>
-              <li>Resist the urge to attack. Instead, try filling in these blanks: <i>“When [the triggering event] happened, I felt [my feeling] because [my need/interest] is really important to me. Would you be willing to [do a do-able action]?”</i></li>
-              <li>Talk to the other person’s best self</li>
-              <li>Differentiate needs, interests, and strategies</li>
-              <li>Acknowledge emotions. See them as signals</li>
-              <li>Differentiate between acknowledgment and agreement</li>
-              <li>When listening, avoid making suggestions</li>
-              <li>Differentiate between evaluation and observation</li>
-              <li>Test your assumptions. Relinquish them if they prove to be false</li>
-              <li>Develop curiosity in difficult situations</li>
-              <li>Assume useful dialogue is possible, even when it seems unlikely</li>
-              <li>If you are making things worse, stop</li>
-              <li>Figure out what’s happening, not whose fault it is</li>
-              <li>Acknowledge conflict. Talk to the right people about the real problem</li>
-              <li>Assume undiscovered options exist. Seek solutions people willingly support</li>
-              <li>Be explicit about agreements. Be explicit when they change</li>
-              <li>Expect and plan for future conflict</li>
-              <li>If someone calls out your privilege, take a step back. Remember not to require others to educate you, and be grateful to those who do</li>
-              <li>Use sarcasm carefully. Tone is hard to decipher online; make judicious use of emoji to aid in communication</li>
-              <li>Apologize when your words have had a hurtful impact. Don’t focus on your intent, and don’t expect immediate forgiveness</li>
-              <li>Sometimes remaining constructive in a conversation feels like too much work, and it's tempting to lose your temper and flame out. Flaming in the community is very much discouraged. Someone in this community will say something bothersome at some point. Anger is a normal emotion, and we don't want to devalue it or deny your experience. If you need to vent, we do want to encourage you to vent away from the person whose words or actions angered you. If you can't stay constructive, here are some options:
-                <ul>
-                  <li>Ping a moderator</li>
-                  <li>Vent at a moderator or buddy off-channel</li>
-                  <li>Ghost out</li>
-                  <li>Declare you’re done, and leave</li>
-                </ul>
-             </li>
-            </ul>
-         </p>
-          <p class="justify">Sources:
-            <ul>
-              <li><a href="http://www.amazon.com/Changing-Conversation-Principles-Conflict-Resolution/dp/0143126865">Changing the Conversation: The 17 Principles for Conflict Resolution</a></li>
-              <li><a href="http://tooyoungforthelivingdead.tumblr.com/called-out">“How to deal with being called out”</a></li>
-            </ul>
-         </p>
+          <ul>
+            <li>
+              Don’t hear attack or police tone. Listen for what is behind the
+              words
+            </li>
+            <li>
+              Resist the urge to attack. Instead, try filling in these blanks:
+              <i
+                >“When [the triggering event] happened, I felt [my feeling]
+                because [my need/interest] is really important to me. Would you
+                be willing to [do a do-able action]?”</i
+              >
+            </li>
+            <li>Talk to the other person’s best self</li>
+            <li>Differentiate needs, interests, and strategies</li>
+            <li>Acknowledge emotions. See them as signals</li>
+            <li>Differentiate between acknowledgment and agreement</li>
+            <li>When listening, avoid making suggestions</li>
+            <li>Differentiate between evaluation and observation</li>
+            <li>
+              Test your assumptions. Relinquish them if they prove to be false
+            </li>
+            <li>Develop curiosity in difficult situations</li>
+            <li>
+              Assume useful dialogue is possible, even when it seems unlikely
+            </li>
+            <li>If you are making things worse, stop</li>
+            <li>Figure out what’s happening, not whose fault it is</li>
+            <li>
+              Acknowledge conflict. Talk to the right people about the real
+              problem
+            </li>
+            <li>
+              Assume undiscovered options exist. Seek solutions people willingly
+              support
+            </li>
+            <li>Be explicit about agreements. Be explicit when they change</li>
+            <li>Expect and plan for future conflict</li>
+            <li>
+              If someone calls out your privilege, take a step back. Remember
+              not to require others to educate you, and be grateful to those who
+              do
+            </li>
+            <li>
+              Use sarcasm carefully. Tone is hard to decipher online; make
+              judicious use of emoji to aid in communication
+            </li>
+            <li>
+              Apologize when your words have had a hurtful impact. Don’t focus
+              on your intent, and don’t expect immediate forgiveness
+            </li>
+            <li>
+              Sometimes remaining constructive in a conversation feels like too
+              much work, and it's tempting to lose your temper and flame out.
+              Flaming in the community is very much discouraged. Someone in this
+              community will say something bothersome at some point. Anger is a
+              normal emotion, and we don't want to devalue it or deny your
+              experience. If you need to vent, we do want to encourage you to
+              vent away from the person whose words or actions angered you. If
+              you can't stay constructive, here are some options:
+              <ul>
+                <li>Ping a moderator</li>
+                <li>Vent at a moderator or buddy off-channel</li>
+                <li>Ghost out</li>
+                <li>Declare you’re done, and leave</li>
+              </ul>
+            </li>
+          </ul>
+          <p class="justify">Sources:</p>
+          <ul>
+            <li>
+              <a
+                href="http://www.amazon.com/Changing-Conversation-Principles-Conflict-Resolution/dp/0143126865"
+                >Changing the Conversation: The 17 Principles for Conflict
+                Resolution</a
+              >
+            </li>
+            <li>
+              <a href="http://tooyoungforthelivingdead.tumblr.com/called-out"
+                >“How to deal with being called out”</a
+              >
+            </li>
+          </ul>
         </div>
       </div>
       {% include 'contactbutton.html' %}
     </div>
   </div>
-{% endblock content %}
+  {% endblock content %}
+</div>

--- a/templates/contactbutton.html
+++ b/templates/contactbutton.html
@@ -1,1 +1,8 @@
-<a href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link" class="contact-us" id="orange-button" target="_blank" rel="noopener noreferrer">Contact us</a>
+<a
+  href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link"
+  class="contact-us"
+  id="orange-button"
+  target="_blank"
+  rel="noopener noreferrer"
+  >Contact us</a
+>

--- a/templates/curriculumdev.html
+++ b/templates/curriculumdev.html
@@ -1,53 +1,89 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Careers
-{% endblock title %}
-
-{% block content %}
-  <div class="row row__center about-us">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
-           alt="A mentor works with a participant at a laptop." 
-           class="fixed-img" style="width:38%;">
-    </div>
-    <div class="column">
-      <h1 class="blue-h1">Openings</h1>
-      <p class="justify">Techtonica is a nonprofit that offers six months of full-time software engineering training with living stipends to Bay Area women and non-binary adults with low incomes. After graduation, Techtonica places graduates into engineering jobs with sponsor companies. You can <a href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc">read more here</a>.</p>
-      <h3>Make an Impact as Our Curriculum Developer!</h3>
-
-      <p class="justify">Techtonica offers a life-changing learning experience to participants. We care deeply about helping our apprentices become high-quality developers.</p>
-
-      <p class="justify">We're looking for a curriculum developer for our six-month, full-time software engineering training. We have existing materials from our first 2018 cohort (see <a href="https://github.com/Techtonica/curriculum/blob/master/README.md">some of the subjects we cover here</a>) that you will build upon and improve. This is a part-time position.</p>
-
-      <p class="justify">Responsibilities:
-      <ul>
-        <li>Decide on the overall plan and pacing for the curriculum, including the balance of lessons, projects, and assessments, while incorporating feedback from the first cohort of apprentices</li>
-        <li>Develop and improve topic outlines, projects, and assessments</li>
-        <li>Break down necessary work into individual pieces that can be developed by volunteers and manage that development</li>
-        <li>Review work of volunteers for accuracy, completeness, and overall quality</li>
-      </ul>
-      </p>
-
-      <p class="justify">What we're looking for:
-        <ul>
-          <li>You can clearly explain technical topics in writing and in a way that is rigorous but can be understood by beginners</li>
-          <li>You know what is needed to become a high-quality, entry-level software engineer and have good ideas about how to get people to that point</li>
-          <li>You have an understanding of socioeconomic differences and experiences that our participants have faced</li>
-        </ul>
-      </p>
-
-      <p class="justify">Preferred previous experience:
-        <ul>
-          <li>Developing a technical curriculum</li>
-          <li>Teaching</li>
-          <li>Professional software development</li>
-        </ul>
-      </p>
-      <p class="justify">
-        This role may lead into <a href="{{ url_for('render_tapm_page') }}">our full-time Technical Apprenticeship Program Manager role</a>.
-      </p>
-      {% include 'contactbutton.html' %}
-    </div>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%;"
+    />
   </div>
+  <div class="column">
+    <h1 class="blue-h1">Openings</h1>
+    <p class="justify">
+      Techtonica is a nonprofit that offers six months of full-time software
+      engineering training with living stipends to Bay Area women and non-binary
+      adults with low incomes. After graduation, Techtonica places graduates
+      into engineering jobs with sponsor companies. You can
+      <a
+        href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc"
+        >read more here</a
+      >.
+    </p>
+    <h3>Make an Impact as Our Curriculum Developer!</h3>
+
+    <p class="justify">
+      Techtonica offers a life-changing learning experience to participants. We
+      care deeply about helping our apprentices become high-quality developers.
+    </p>
+
+    <p class="justify">
+      We're looking for a curriculum developer for our six-month, full-time
+      software engineering training. We have existing materials from our first
+      2018 cohort (see
+      <a href="https://github.com/Techtonica/curriculum/blob/master/README.md"
+        >some of the subjects we cover here</a
+      >) that you will build upon and improve. This is a part-time position.
+    </p>
+
+    <p class="justify">Responsibilities:</p>
+    <ul>
+      <li>
+        Decide on the overall plan and pacing for the curriculum, including the
+        balance of lessons, projects, and assessments, while incorporating
+        feedback from the first cohort of apprentices
+      </li>
+      <li>Develop and improve topic outlines, projects, and assessments</li>
+      <li>
+        Break down necessary work into individual pieces that can be developed
+        by volunteers and manage that development
+      </li>
+      <li>
+        Review work of volunteers for accuracy, completeness, and overall
+        quality
+      </li>
+    </ul>
+
+    <p class="justify">What we're looking for:</p>
+    <ul>
+      <li>
+        You can clearly explain technical topics in writing and in a way that is
+        rigorous but can be understood by beginners
+      </li>
+      <li>
+        You know what is needed to become a high-quality, entry-level software
+        engineer and have good ideas about how to get people to that point
+      </li>
+      <li>
+        You have an understanding of socioeconomic differences and experiences
+        that our participants have faced
+      </li>
+    </ul>
+
+    <p class="justify">Preferred previous experience:</p>
+    <ul>
+      <li>Developing a technical curriculum</li>
+      <li>Teaching</li>
+      <li>Professional software development</li>
+    </ul>
+    <p class="justify">
+      This role may lead into
+      <a href="{{ url_for('render_tapm_page') }}"
+        >our full-time Technical Apprenticeship Program Manager role</a
+      >.
+    </p>
+    {% include 'contactbutton.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -1,49 +1,92 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap
-{% endblock title %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block content %}
 <div class="row row__center blue-background">
   <div class="column">
     <h1>Help us bridge the tech gap</h1>
-    <p class="justify">Donate today to directly benefit the participants of our six-month tech apprenticeship program, help increase diversity in tech, and empower locals in need!</p>
+    <p class="justify">
+      Donate today to directly benefit the participants of our six-month tech
+      apprenticeship program, help increase diversity in tech, and empower
+      locals in need!
+    </p>
   </div>
   <div class="column">
-    <img src="{{ url_for('static', filename='img/group-workshop-min.jpg') }}" alt="Volunteers and students taking a group picture" class="full-width-img">
+    <img
+      src="{{ url_for('static', filename='img/group-workshop-min.jpg') }}"
+      alt="Volunteers and students taking a group picture"
+      class="full-width-img"
+    />
   </div>
 </div>
-{<div class="row row__center what-we-do" id="whatwedo" style="padding-bottom:0;">
+{
+<div
+  class="row row__center what-we-do"
+  id="whatwedo"
+  style="padding-bottom: 0;"
+>
   <h1 class="blue-h1">How to Donate</h1>
 </div>
 
-<div class="row" style="padding-top:0;">
+<div class="row" style="padding-top: 0;">
   <div class="column">
     <h2>Credit Card</h2>
-    <h3><a href="http://techtonica.wedid.it/" class="sponsor" target="_blank" rel="noopener noreferrer">Click here to donate with a card.</a></h3>
+    <h3>
+      <a
+        href="http://techtonica.wedid.it/"
+        class="sponsor"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Click here to donate with a card.</a
+      >
+    </h3>
   </div>
   <div class="column">
     <h2>Venmo</h2>
-    <h3><a href="#" onclick="return false;" class="sponsor" target="_blank" rel="noopener noreferrer">Venmo your donation to @socialgoodfund (Social Good Fund Executive Director Michael Pace) and indicate it's for Techtonica.</a></h3>
+    <h3>
+      <a
+        href="#"
+        onclick="return false;"
+        class="sponsor"
+        target="_blank"
+        rel="noopener noreferrer"
+        >Venmo your donation to @socialgoodfund (Social Good Fund Executive
+        Director Michael Pace) and indicate it's for Techtonica.</a
+      >
+    </h3>
   </div>
   <div class="column">
     <h2>Direct Deposit</h2>
-    <h3><a href="#" onclick="return false;" class="sponsor" target="_blank" rel="noopener noreferrer">Account owner: Social Good Fund</br>
-    Bank: Chase</br>
-    Account number: 200399753</br>
-    Routing number: 071000013</br>
-    Note: For Techtonica</br>
-    Then fill out a <object><a href = https://docs.google.com/forms/d/e/1FAIpQLSdHtWIvwCV7PED5tDt8Wura-py8-Voqtepj5n1HTtU8Usmv5A/viewform class="link-on-blue">deposit form </a>or <a href = https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform class="link-on-blue">contact form</a> to let us know.</object></a></h3>
+    <h3 class="sponsor" target="_blank" rel="noopener noreferrer">
+      Account owner: Social Good Fund<br />
+      Bank: Chase<br />
+      Account number: 200399753<br />
+      Routing number: 071000013<br />
+      Note: For Techtonica<br />
+      Then fill out a
+      <a
+        href="https://docs.google.com/forms/d/e/1FAIpQLSdHtWIvwCV7PED5tDt8Wura-py8-Voqtepj5n1HTtU8Usmv5A/viewform"
+        class="link-on-blue"
+        >deposit form</a
+      >
+      or
+      <a
+        href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform"
+        class="link-on-blue"
+        >contact form</a
+      >
+      to let us know.
+    </h3>
   </div>
   <div class="column">
     <h2>Check</h2>
-    <h3><a href="#" onclick="return false;" class="sponsor" target="_blank" rel="noopener noreferrer">Write your check to Social Good Fund, indicate it's for Techtonica on the memo line, and mail it to: </br>
-      Social Good Fund</br>
-      P.O. Box 5473</br>
-      Richmond, CA 94805</a><h3>
+    <h3 class="sponsor" target="_blank" rel="noopener noreferrer">
+      Write your check to Social Good Fund, indicate it's for Techtonica on the
+      memo line, and mail it to: <br />
+      Social Good Fund<br />
+      P.O. Box 5473<br />
+      Richmond, CA 94805
+    </h3>
   </div>
-<!--   <div class="column">
+  <!--   <div class="column">
     <h2>Amazon</h2>
     <h3><a href="https://www.amazon.com/registry/wishlist/1XEZ5MMI0XLQF/ref=cm_sw_r_cp_ep_ws_aMCUAb3W607XK" class="sponsor" target="_blank" rel="noopener noreferrer">Purchase an item from our Amazon wish list.</a></h3>
   </div> -->

--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -1,108 +1,305 @@
-{% extends "base.html" %}
-
-{% block title %}
-	Techtonica: Bridging the Tech Gap — FAQs
-{% endblock title %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+FAQs {% endblock title %} {% block content %}
 
 <div class="row row__center what-we-do" id="whatwedo">
   <div class="column">
     <h1 class="blue-h1">Frequently Asked Questions About Techtonica</h1>
-<p>&nbsp;</p>
-<h3>What is your one-sentence description of Techtonica?</h3>
-<p id="unique">Techtonica partners with tech companies to provide free tech training, laptops, living stipends, and job placement to women and non-binary adults in need in the Bay Area.</p>
-<p>&nbsp;</p>
-<h3 id="different">What makes Techtonica different?</h3>
-<p>We offer underserved, diverse populations an opportunity to be involved in a long-term, tuition free, full-time program that prepares and places them in the software engineering field without having to worry about financial instability. The main differences between us and other programs are:</p>
-<ul>
-<li>Our participants are <strong>local women and non-binary adults with low incomes, </strong>preventing more displacement and empowering the people who really need tech skills</li>
-<li>92% of our participants so far have been <strong>people of color</strong>, 25% have a <strong>disability</strong>, 10% identify <strong>outside the gender binary</strong>, and 8% are <strong>veterans</strong></li>
-<li>Our program is <strong>free</strong> for participants</li>
-<li>We provide stipends to help our participants with<strong> living and childcare costs</strong></li>
-<li>We are a <strong>nonprofit, so donations are tax-deductible</strong></li>
-<li>We provide <strong>laptops</strong></li>
-<li>Our program is <strong>six months long</strong> instead of just three​</li>
-<li>Our program ends with a <strong>job</strong> and <strong>professional connections</strong> in the industry</li>
-<li>We expose participants to a <strong>variety of roles</strong> in the tech industry, not solely the role of software engineer&mdash;our goal is to find great fits for our participants and help them support themselves and their families</li>
-<li>We encourage participants to be <strong>leaders</strong> in the community</li>
-<li>We organize intro coding workshops with <strong>local organizations</strong> to reach the local community</li>
-<li>Our program is more <strong>age-inclusive</strong>&mdash;it's not just for young adults</li>
-<li>We provide <strong>ongoing support</strong> to our graduates</li>
-<li><strong>Partner companies</strong> are involved in criteria, curriculum, and mentoring</li>
-<li>Our curriculum is <strong>open-source</strong></li>
-<li>We provide <strong>diversity and inclusion training</strong> to the teams that our graduates will be placed onto</li>
-</ul>
-<p>&nbsp;</p>
-<h3 id="definitions">What do &ldquo;genderqueer,&rdquo; &ldquo;non-binary,&rdquo; and &ldquo;femme&rdquo; or &ldquo;femme-presenting&rdquo; mean?</h3>
-<p>Genderqueer and non-binary are terms that describe people who do not identify as men or women. &ldquo;Femme&rdquo; refers to people&rsquo;s appearance. A more traditionally-feminine appearance is considered femme. We are trans-inclusive. We serve and accept cis and trans women, as well as people with non-binary gender identities.</p>
-<p>&nbsp;</p>
-<h3 id="participants">What is Techtonica looking for in participants?</h3>
-<p>We are seeking participants who can show consistent responsibility, resilience, commitment, and interest, among other criteria that our partner companies work out with us. See our <a href="{{ url_for('render_apprenticeship_page') }}">apprenticeship page</a> for more information.</p>
-<p>&nbsp;</p>
-<h3 id="sign-up">I'm interested in being a participant in your program. How do I sign up?</h3>
-<p>See if you're eligible on our <a href="{{ url_for('render_apprenticeship_page') }}">apprenticeship page</a>. If you're eligible and our applications are open (as indicated on our social media accounts), you can apply by following the instructions.
-<p>&nbsp;</p>
-<h3 id="companies">What is Techtonica looking for in companies?</h3>
-<p>We are seeking companies that are interested in increasing diversity and social impact, committed to learning about and encouraging inclusion, supportive of junior engineers, etc.</p>
-<p>&nbsp;</p>
-<h3 id="low-income">What is considered low-income?</h3>
-<p>For most area nonprofits: </p>
-<p>For a family: less than $39,000 annually</p>
-<p>For an individual: less than $24,000 annually</p>
-<p>For Techtonica:</p>
-<p>Less than $50,000 annually</p>
-<p>&nbsp;</p>
-<h3 id="age-limit">Is there an age limit?</h3>
-<p>Adults, ages 18 and up</p>
-<p>&nbsp;</p>
-<h3 id="duration">How long is Techtonica's full-time program?</h3>
-<p>It is full-time, Monday through Friday, for six months.</p>
-<p>&nbsp;</p>
-<h3 id="where">Where does Techtonica's program take place?</h3>
-<p>The program currently takes place in San Francisco.</p>
-<p>&nbsp;</p>
-<h3 id="subjects">Which subjects will be covered? What does the curriculum cover? What level of training do you provide?</h3>
-<p>The curriculum covers mostly web development (full-stack JavaScript), but we also do sections on other skills useful in tech, such as project management, UI/UX design, and data analysis. Sponsoring companies have a say in what should be added or improved upon. Feel free to check out and contribute to <a href="https://github.com/Techtonica/curriculum" target="_blank">our open-source curriculum</a>.</p>
-<p>&nbsp;</p>
-<h3 id="cut-from-salaries">Why don't you just take a cut from graduates' salaries following the program?</h3>
-<p>We believe in empowering underrepresented folks, rather than placing an additional burden on them. </p>
-<p>&nbsp;</p>
-<h3 id="job-placements">Why does your program end with job placement?</h3>
-<p>Being underrepresented and without connections in the tech industry makes it very difficult to find a job. Companies are working to increase diversity, and underprivileged locals are seeking employment, so why not help each other?</p>
-<p>&nbsp;</p>
-<h3 id="sponsor-levels-and-benefits">What are the sponsor levels and benefits?</h3>
-<p>See <a href="{{ url_for('render_sponsor_page') }}">our sponsorships page.</a>
-<p>&nbsp;</p>
-<h3 id="hiring">Do sponsors get to select participants for employment?</h3>
-<p>Advocate-level sponsors can get involved with the training and curriculum, so they get to know participants over the span of the six months. Around the fifth month, companies and participants interview and rate each other and we do our best to align you so both sides are happy.
-<p>&nbsp;</p>
-<h3 id="topics-in-diversity-training">What topics are included in the diversity and inclusion training for sponsors?</h3>
-<p>Implicit bias, privilege, allyship, empathy, inclusion vs. diversity, apologizing, tools for inclusive hiring, why policies are important, giving actionable feedback, etc.
-<p>&nbsp;</p>
-<h3 id="tax-exempt-donations">Are my donations tax-exempt?</h3>
-<p>Yes, because our fiscal sponsor <a href="http://www.socialgoodfund.org">Social Good Fund</a> has 501(c)(3) status.</p>
-<p>&nbsp;</p>
-<h3 id="fiscal-sponsorship">Why do donations go to Social Good Fund?</h3>
-<p>We are fiscally sponsored through <a href="http://www.socialgoodfund.org">Social Good Fund</a>. Fiscal sponsorship is when a 501(c)(3) nonprofit organization—the “fiscal sponsor”—takes on a project like Techtonica, thus sharing legal and tax-exempt status. We give them a percentage of our donations and they manage our employment, donations, payroll, and taxes. They offer the same services to <a href="https://www.socialgoodfund.org/fiscal-sponsorship/current-projects/" target="_blank">over 50 organizations</a>, so their tax documents reflect the information for all of those organizations.</p>
-<p>&nbsp;</p>
-<h3 id="how-to-donate">How do I donate?</h3>
-<p>Thank you! You can donate once or regularly <a href="https://techtonica.org/donate/">here</a>. Since our fiscal sponsor is <a href="http://www.socialgoodfund.org">Social Good</a>, all donations will be sent to them first before being distributed to us. Please <a href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform">send us a message</a> when you donate so that we know to inform Social Good and they can place your donation into our account.</p>
-<p>&nbsp;</p>
-<h3 id="other-ways-to-help">What else can we do besides sponsoring and hiring?</h3>
-<ul>
-<li><a href="https://twitter.com/TechtonicaOrg/status/842485189531983872">Provide space</a> for our full-time program, workshops, or events.</li>
-<li><a href="https://techtonica.wedid.it/">Make donations</a>.</li>
-<li><a href="https://goo.gl/forms/jgD3BWCEg5RN8XwN2">Sign up to volunteer</a> your skills to the cause.</li>
-<li>Spread the word via <a href="https://twitter.com/TechtonicaOrg" target="_blank" title="Twitter">Twitter</a>, <a href="https://www.linkedin.com/company/techtonica/" target="_blank" title="LinkedIn">LinkedIn</a>, <a href="https://www.facebook.com/Techtonica/" target="_blank" title="Facebook">Facebook</a>, <a href="https://medium.com/techtonica/" target="_blank" title="Medium">Medium</a>, and <a href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg" target="_blank" title="YouTube">YouTube</a>.</li>
-</ul>
-<p>&nbsp;</p>
-<h3 id="name">Where did the name 'Techtonica' come from?</h3>
-<p>Our founder Michelle Glauser liked the idea of Techtonica being a "tonic" or "solution" for tech and a technical solution for neighbors in need. She also likes the "moving and shaking" that the name implies. The A at the end just fits, you know?</p>
-<p>&nbsp;</p>
-<h3 id="contact">How do we contact you?</h3>
-<p>We would love to hear from you! Reach out to us through <a href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link">this form</a>.</p>
-<p>&nbsp;</p>
+    <p>&nbsp;</p>
+    <h3>What is your one-sentence description of Techtonica?</h3>
+    <p id="unique">
+      Techtonica partners with tech companies to provide free tech training,
+      laptops, living stipends, and job placement to women and non-binary adults
+      in need in the Bay Area.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="different">What makes Techtonica different?</h3>
+    <p>
+      We offer underserved, diverse populations an opportunity to be involved in
+      a long-term, tuition free, full-time program that prepares and places them
+      in the software engineering field without having to worry about financial
+      instability. The main differences between us and other programs are:
+    </p>
+    <ul>
+      <li>
+        Our participants are
+        <strong>local women and non-binary adults with low incomes, </strong
+        >preventing more displacement and empowering the people who really need
+        tech skills
+      </li>
+      <li>
+        92% of our participants so far have been
+        <strong>people of color</strong>, 25% have a
+        <strong>disability</strong>, 10% identify
+        <strong>outside the gender binary</strong>, and 8% are
+        <strong>veterans</strong>
+      </li>
+      <li>Our program is <strong>free</strong> for participants</li>
+      <li>
+        We provide stipends to help our participants with<strong>
+          living and childcare costs</strong
+        >
+      </li>
+      <li>
+        We are a <strong>nonprofit, so donations are tax-deductible</strong>
+      </li>
+      <li>We provide <strong>laptops</strong></li>
+      <li>
+        Our program is <strong>six months long</strong> instead of just three​
+      </li>
+      <li>
+        Our program ends with a <strong>job</strong> and
+        <strong>professional connections</strong> in the industry
+      </li>
+      <li>
+        We expose participants to a <strong>variety of roles</strong> in the
+        tech industry, not solely the role of software engineer&mdash;our goal
+        is to find great fits for our participants and help them support
+        themselves and their families
+      </li>
+      <li>
+        We encourage participants to be <strong>leaders</strong> in the
+        community
+      </li>
+      <li>
+        We organize intro coding workshops with
+        <strong>local organizations</strong> to reach the local community
+      </li>
+      <li>
+        Our program is more <strong>age-inclusive</strong>&mdash;it's not just
+        for young adults
+      </li>
+      <li>We provide <strong>ongoing support</strong> to our graduates</li>
+      <li>
+        <strong>Partner companies</strong> are involved in criteria, curriculum,
+        and mentoring
+      </li>
+      <li>Our curriculum is <strong>open-source</strong></li>
+      <li>
+        We provide <strong>diversity and inclusion training</strong> to the
+        teams that our graduates will be placed onto
+      </li>
+    </ul>
+    <p>&nbsp;</p>
+    <h3 id="definitions">
+      What do &ldquo;genderqueer,&rdquo; &ldquo;non-binary,&rdquo; and
+      &ldquo;femme&rdquo; or &ldquo;femme-presenting&rdquo; mean?
+    </h3>
+    <p>
+      Genderqueer and non-binary are terms that describe people who do not
+      identify as men or women. &ldquo;Femme&rdquo; refers to people&rsquo;s
+      appearance. A more traditionally-feminine appearance is considered femme.
+      We are trans-inclusive. We serve and accept cis and trans women, as well
+      as people with non-binary gender identities.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="participants">What is Techtonica looking for in participants?</h3>
+    <p>
+      We are seeking participants who can show consistent responsibility,
+      resilience, commitment, and interest, among other criteria that our
+      partner companies work out with us. See our
+      <a href="{{ url_for('render_apprenticeship_page') }}"
+        >apprenticeship page</a
+      >
+      for more information.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="sign-up">
+      I'm interested in being a participant in your program. How do I sign up?
+    </h3>
+    <p>
+      See if you're eligible on our
+      <a href="{{ url_for('render_apprenticeship_page') }}"
+        >apprenticeship page</a
+      >. If you're eligible and our applications are open (as indicated on our
+      social media accounts), you can apply by following the instructions.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="companies">What is Techtonica looking for in companies?</h3>
+    <p>
+      We are seeking companies that are interested in increasing diversity and
+      social impact, committed to learning about and encouraging inclusion,
+      supportive of junior engineers, etc.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="low-income">What is considered low-income?</h3>
+    <p>For most area nonprofits:</p>
+    <p>For a family: less than $39,000 annually</p>
+    <p>For an individual: less than $24,000 annually</p>
+    <p>For Techtonica:</p>
+    <p>Less than $50,000 annually</p>
+    <p>&nbsp;</p>
+    <h3 id="age-limit">Is there an age limit?</h3>
+    <p>Adults, ages 18 and up</p>
+    <p>&nbsp;</p>
+    <h3 id="duration">How long is Techtonica's full-time program?</h3>
+    <p>It is full-time, Monday through Friday, for six months.</p>
+    <p>&nbsp;</p>
+    <h3 id="where">Where does Techtonica's program take place?</h3>
+    <p>The program currently takes place in San Francisco.</p>
+    <p>&nbsp;</p>
+    <h3 id="subjects">
+      Which subjects will be covered? What does the curriculum cover? What level
+      of training do you provide?
+    </h3>
+    <p>
+      The curriculum covers mostly web development (full-stack JavaScript), but
+      we also do sections on other skills useful in tech, such as project
+      management, UI/UX design, and data analysis. Sponsoring companies have a
+      say in what should be added or improved upon. Feel free to check out and
+      contribute to
+      <a href="https://github.com/Techtonica/curriculum" target="_blank"
+        >our open-source curriculum</a
+      >.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="cut-from-salaries">
+      Why don't you just take a cut from graduates' salaries following the
+      program?
+    </h3>
+    <p>
+      We believe in empowering underrepresented folks, rather than placing an
+      additional burden on them.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="job-placements">Why does your program end with job placement?</h3>
+    <p>
+      Being underrepresented and without connections in the tech industry makes
+      it very difficult to find a job. Companies are working to increase
+      diversity, and underprivileged locals are seeking employment, so why not
+      help each other?
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="sponsor-levels-and-benefits">
+      What are the sponsor levels and benefits?
+    </h3>
+    <p>
+      See
+      <a href="{{ url_for('render_sponsor_page') }}">our sponsorships page.</a>
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="hiring">Do sponsors get to select participants for employment?</h3>
+    <p>
+      Advocate-level sponsors can get involved with the training and curriculum,
+      so they get to know participants over the span of the six months. Around
+      the fifth month, companies and participants interview and rate each other
+      and we do our best to align you so both sides are happy.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="topics-in-diversity-training">
+      What topics are included in the diversity and inclusion training for
+      sponsors?
+    </h3>
+    <p>
+      Implicit bias, privilege, allyship, empathy, inclusion vs. diversity,
+      apologizing, tools for inclusive hiring, why policies are important,
+      giving actionable feedback, etc.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="tax-exempt-donations">Are my donations tax-exempt?</h3>
+    <p>
+      Yes, because our fiscal sponsor
+      <a href="http://www.socialgoodfund.org">Social Good Fund</a> has 501(c)(3)
+      status.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="fiscal-sponsorship">Why do donations go to Social Good Fund?</h3>
+    <p>
+      We are fiscally sponsored through
+      <a href="http://www.socialgoodfund.org">Social Good Fund</a>. Fiscal
+      sponsorship is when a 501(c)(3) nonprofit organization—the “fiscal
+      sponsor”—takes on a project like Techtonica, thus sharing legal and
+      tax-exempt status. We give them a percentage of our donations and they
+      manage our employment, donations, payroll, and taxes. They offer the same
+      services to
+      <a
+        href="https://www.socialgoodfund.org/fiscal-sponsorship/current-projects/"
+        target="_blank"
+        >over 50 organizations</a
+      >, so their tax documents reflect the information for all of those
+      organizations.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="how-to-donate">How do I donate?</h3>
+    <p>
+      Thank you! You can donate once or regularly
+      <a href="https://techtonica.org/donate/">here</a>. Since our fiscal
+      sponsor is <a href="http://www.socialgoodfund.org">Social Good</a>, all
+      donations will be sent to them first before being distributed to us.
+      Please
+      <a
+        href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform"
+        >send us a message</a
+      >
+      when you donate so that we know to inform Social Good and they can place
+      your donation into our account.
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="other-ways-to-help">
+      What else can we do besides sponsoring and hiring?
+    </h3>
+    <ul>
+      <li>
+        <a href="https://twitter.com/TechtonicaOrg/status/842485189531983872"
+          >Provide space</a
+        >
+        for our full-time program, workshops, or events.
+      </li>
+      <li><a href="https://techtonica.wedid.it/">Make donations</a>.</li>
+      <li>
+        <a href="https://goo.gl/forms/jgD3BWCEg5RN8XwN2"
+          >Sign up to volunteer</a
+        >
+        your skills to the cause.
+      </li>
+      <li>
+        Spread the word via
+        <a
+          href="https://twitter.com/TechtonicaOrg"
+          target="_blank"
+          title="Twitter"
+          >Twitter</a
+        >,
+        <a
+          href="https://www.linkedin.com/company/techtonica/"
+          target="_blank"
+          title="LinkedIn"
+          >LinkedIn</a
+        >,
+        <a
+          href="https://www.facebook.com/Techtonica/"
+          target="_blank"
+          title="Facebook"
+          >Facebook</a
+        >,
+        <a href="https://medium.com/techtonica/" target="_blank" title="Medium"
+          >Medium</a
+        >, and
+        <a
+          href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg"
+          target="_blank"
+          title="YouTube"
+          >YouTube</a
+        >.
+      </li>
+    </ul>
+    <p>&nbsp;</p>
+    <h3 id="name">Where did the name 'Techtonica' come from?</h3>
+    <p>
+      Our founder Michelle Glauser liked the idea of Techtonica being a "tonic"
+      or "solution" for tech and a technical solution for neighbors in need. She
+      also likes the "moving and shaking" that the name implies. The A at the
+      end just fits, you know?
+    </p>
+    <p>&nbsp;</p>
+    <h3 id="contact">How do we contact you?</h3>
+    <p>
+      We would love to hear from you! Reach out to us through
+      <a
+        href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link"
+        >this form</a
+      >.
+    </p>
+    <p>&nbsp;</p>
   </div>
 </div>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,377 +1,757 @@
-{% extends "base.html" %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block content %}
+<div class="main-content">
+  <div class="main-header">
+    <div class="main-header__text blue-background">
+      <h1 class="main-header__header">#BridgeTheTechGap</h1>
+      <p>
+        We offer six months of free, full-time tech training with living
+        stipends and laptops to Bay Area women and non-binary adults with low
+        incomes, then place graduates into jobs with sponsor companies.
+      </p>
+      <h2>
+        <a
+          href="{{ url_for('render_apprenticeship_page') }}"
+          class="sponsor"
+          id="orange-button"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Sponsor today!</a
+        >
+      </h2>
+    </div>
+  </div>
+  <div class="row row__center what-we-do" id="whatwedo">
+    <div class="column">
+      <h1 class="blue-h1">Our Apprentices</h1>
+      <p class="justify">
+        Is your company hiring engineers? Do you care about your social
+        footprint and diversity? We are seeking sponsors for our apprentices,
+        who make it through a rigorous, lengthy application process that
+        includes multiple workshops, interviews, and a code challenge. By the
+        time each cohort graduates and is ready for placement on your team, they
+        will have done more than 1,000 hours of collaborative, project-based
+        learning developed by industry professionals. To secure one of the
+        apprentices for your team, please
+        <a href="{{ url_for('render_sponsor_page') }}"
+          >check out more details here</a
+        >
+        and get in touch!
+      </p>
+    </div>
 
-{% block title %}
-  Techtonica: Bridging the Tech Gap
-{% endblock title %}
+    <div class="column">
+      <a href="{{ url_for('render_sponsor_page') }}">
+        <img
+          src="{{ url_for('static', filename='img/apprentices-2018-min.jpg') }}"
+          alt="2018 apprenticeship cohort"
+          class="full-width-img"
+        />
+      </a>
+    </div>
+  </div>
+  <div class="row row__center blue-background why-why" id="why">
+    <div class="column">
+      <img
+        src="{{ url_for('static', filename='img/Tenderloin.jpg') }}"
+        alt="Street, sidewalks, and building in the Tenderloin neighborhood of San Francisco."
+        class="full-width-img"
+      />
+    </div>
+    <div class="column">
+      <h1>Why</h1>
+      <p class="justify">
+        The tech industry in the Bay Area is causing displacement and increasing
+        income disparity. The industry also needs to build more diverse
+        technical teams.
+      </p>
+      <p class="justify">
+        We asked, "What if we could help tech companies build much-needed
+        diverse technical teams by having them sponsor training for and hire
+        underrepresented, underprivileged locals who need jobs the most?"
+      </p>
+    </div>
+  </div>
+  <div class="row row__baseline how-it-works" id="howitworks">
+    <h1 class="blue-h1">How it Works</h1>
+    <div class="row">
+      <div class="column column-med centered">
+        <img
+          src="{{ url_for('static', filename='img/lightbulb.png') }}"
+          alt=""
+          aria-hidden="true"
+        />
+        <h3>Vetting</h3>
+        <p>
+          Techtonica conducts free intro workshops with local organizations and
+          labs.
+        </p>
+        <p>
+          We invite the most resilient, independent, committed, positive,
+          collaborative, curious, calm participants to apply to be full-time
+          apprentices.
+        </p>
+      </div>
+      <div class="column column-med centered">
+        <img
+          src="{{ url_for('static', filename='img/conversation.png') }}"
+          alt=""
+          aria-hidden="true"
+        />
+        <h3>Sponsor Companies</h3>
+        <p>
+          Companies that have sponsored at the Advocate Level
+          <a href="{{ url_for('render_sponsor_page') }}"
+            >cover the apprentices' pre-placement training</a
+          >
+          and provide mentors.
+        </p>
+        <p>
+          They have a say in the curriculum and receive inclusion training in
+          preparation for employing their top-rated apprentices at the end of
+          the program.
+        </p>
+      </div>
+      <div class="column column-med centered">
+        <img
+          src="{{ url_for('static', filename='img/chalkboard.jpg') }}"
+          alt=""
+          aria-hidden="true"
+        />
+        <h3>Apprenticeship</h3>
+        <p>
+          Accepted apprentices receive living stipends, laptops, and more than
+          1,000 hours of full-time, project-based, collaborative training.
+        </p>
+        <p>
+          Upon completion of the program, apprentices are placed with hiring
+          partners.
+        </p>
+      </div>
+    </div>
+  </div>
 
-{% block content %}
-  <div class="main-content">
-      <div class="main-header">
-        <div class="main-header__text blue-background">
-          <h1 class="main-header__header">#BridgeTheTechGap</h1>
-          <p>We offer six months of free, full-time tech training with living stipends and laptops to Bay Area women and non-binary adults with low incomes, then place graduates into jobs with sponsor companies.</p>
-          <h2><a href="{{ url_for('render_apprenticeship_page') }}" class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Sponsor today!</a></h2>
-        </div>
+  <div class="row row__baseline blue-background">
+    <h1>Upcoming Events</h1>
+    <div class="row row__center blue-background">
+      {% if not events %}
+      <h3>Event data currently unavailable. Please check back later!</h3>
+      {% endif %} {% for event in events %}
+      <div class="column centered blue-background event-item" id="eventbrite">
+        <h3 class="blue-background">
+          <a href="{{event.url}}">{{event.title}}</a>
+        </h3>
+        <p class="event-item__address blue-background">{{event.date}}</p>
+        {% if event.venue %}
+        <p class="event-item__address blue-background">
+          {{event.venue}} {% for a in event.address %} <br />{{a}} {% endfor %}
+        </p>
+        {% endif %}
       </div>
-      <div class="row row__center what-we-do" id="whatwedo">
-        <div class="column">
-          <h1 class="blue-h1">Our Apprentices</h1>
-          <p class="justify">Is your company hiring engineers? Do you care about your social footprint and diversity? We are seeking sponsors for our apprentices, who make it through a rigorous, lengthy application process that includes multiple workshops, interviews, and a code challenge. By the time each cohort graduates and is ready for placement on your team, they will have done more than 1,000 hours of collaborative, project-based learning developed by industry professionals. To secure one of the apprentices for your team, please <a href="{{ url_for('render_sponsor_page') }}">check out more details here</a> and get in touch!
-        </div>
-        <div class="column">
-          <a href="{{ url_for('render_sponsor_page') }}">
-            <img src="{{ url_for('static', filename='img/apprentices-2018-min.jpg') }}" alt="2018 apprenticeship cohort" class="full-width-img">
-          </a>
-        </div>
-      </div>
-      <div class="row row__center blue-background why-why" id="why">
-        <div class="column">
-          <img src="{{ url_for('static', filename='img/Tenderloin.jpg') }}" alt="Street, sidewalks, and building in the Tenderloin neighborhood of San Francisco." class="full-width-img">
-        </div>
-        <div class="column">
-          <h1>Why</h1>
-          <p class="justify">The tech industry in the Bay Area is causing displacement and increasing income disparity. The industry also needs to build more diverse technical teams.</p>
-          <p class="justify">We asked, "What if we could help tech companies build much-needed diverse technical teams by having them sponsor training for and hire underrepresented, underprivileged locals who need jobs the most?"</p>
-        </div>
-      </div>
-      <div class="row row__baseline how-it-works" id="howitworks">
-        <h1 class="blue-h1">How it Works</h1>
-        <div class="row">
-            <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/lightbulb.png') }}" alt="" aria-hidden="true">
-              <h3>Vetting</h3>
-              <p>Techtonica conducts free intro workshops with local organizations and labs.</p> <p>We invite the most resilient, independent, committed, positive, collaborative, curious, calm participants to apply to be full-time apprentices.</p>
-            </div>
-            <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/conversation.png') }}" alt="" aria-hidden="true">
-              <h3>Sponsor Companies</h3>
-              <p>Companies that have sponsored at the Advocate Level <a href="{{ url_for('render_sponsor_page') }}">cover the apprentices' pre-placement training</a> and provide mentors.</p>
-              <p>They have a say in the curriculum and receive inclusion training in preparation for employing their top-rated apprentices at the end of the program.</p>
-            </div>
-            <div class="column column-med centered">
-              <img src="{{ url_for('static', filename='img/chalkboard.jpg') }}" alt="" aria-hidden="true">
-              <h3>Apprenticeship</h3>
-              <p>Accepted apprentices receive living stipends, laptops, and more than 1,000 hours of full-time, project-based, collaborative training.</p>
-              <p>Upon completion of the program, apprentices are placed with hiring partners.</p>
-            </div>
-        </div>
-      </div>
+      {% endfor %}
+    </div>
+  </div>
 
-      <div class="row row__baseline blue-background">
-        <h1>Upcoming Events</h1>
-        <div class="row row__center blue-background">
-          {% if not events %}
-            <h3>Event data currently unavailable. Please check back later!</h3>
-          {% endif %}
-          {% for event in events %}
-            <div class="column centered blue-background event-item" id="eventbrite">
-              <h3 class="blue-background"><a href="{{event.url}}">{{event.title}}</a></h3>
-              <p class="event-item__address blue-background">{{event.date}}</p>
-              {% if event.venue %}
-              <p class="event-item__address blue-background">{{event.venue}}
-                {% for a in event.address %}
-                  <br>{{a}}
-                {% endfor %}
-              </p>
-              {% endif %}
-            </div>
-          {% endfor %}
-        </div>
+  <div class="row row__center our-supporters" id="supporters">
+    <h1 class="blue-h1">Thank you for your support!</h1>
+    <div class="row">
+      <div class="column centered">
+        <a href="http://sfpl.org/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}"
+            alt="San Francisco Public Library logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://blog.rackspace.com/the-rackspace-startup-program"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/rackspace-startups-logo.png') }}"
+            alt="Rackspace Startups logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.stanthonysf.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/st-anthonys.jpg') }}"
+            alt="St. Anthony Foundation logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.zendesk.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/zendesk-logo-min.png') }}"
+            alt="Zendesk logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.python.org/psf/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/python-software-foundation-logo.jpg') }}"
+            alt="Python Software Foundation logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="http://www.kaporcenter.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/kapor-center-for-social-impact-logo.jpg') }}"
+            alt="Kapor Center for Social Impact logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.scienceexchange.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/scienceexchange_logo.png') }}"
+            alt="Science Exchange logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.beezwax.net"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/beezwax-logo.png')}}"
+            alt="Beezwax logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="http://sfpl.org/?pg=0200006301"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/bridge-at-main.jpg') }}"
+            alt="The Bridge at Main: Learning resources, classes, and people who can help."
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://stripe.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/stripe.png') }}"
+            alt="Stripe logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://pantheon.io/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/pantheon-logo-min.jpg') }}"
+            alt="Pantheon.io logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://redfin.com" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/redfin-logo.png') }}"
+            alt="Redfin logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://exygy.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/exygy-logo-min.jpg') }}"
+            alt="Exygy logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.cloverhealth.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/clover-health-logo-min.png') }}"
+            alt="Clover Health logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://worldwidewomen.co/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/world-wide-women-min.png') }}"
+            alt="WorldWideWomen logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.moo.com/us/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/moo-logo-min.png') }}"
+            alt="Moo logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.quantcast.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/quantcast-logo-min.png') }}"
+            alt="Quantcast logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.ancestry.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/ancestry-logo-min.png') }}"
+            alt="Ancestry logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.wikimedia.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/wikimedia-foundation-logo-min.png') }}"
+            alt="Wikimedia Foundation logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://github.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/github-logo-min.png') }}"
+            alt="GitHub logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.hugeinc.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/huge-logo-min.png') }}"
+            alt="Huge logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://mixpanel.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/mixpanel-logo-min.png') }}"
+            alt="Mixpanel logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.rallyhealth.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/rally-health-logo-min.png') }}"
+            alt="Rally Health logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.techhireoakland.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/TechHire-logo-min.png') }}"
+            alt="TechHire logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.onelogin.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/onelogin-logo-min.png') }}"
+            alt="OneLogin logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.agari.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/agari-logo-min.png') }}"
+            alt="Agari logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.kintone.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/kintone-logo-min.png') }}"
+            alt="Kintone logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.autonomic.ai/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Autonomic-logo-min.png') }}"
+            alt="Autonomic logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://mailchimp.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/mailchimp-logo-min.png') }}"
+            alt="Mailchimp logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://virtualpostmail.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/virtualpostmail-logo-min.png') }}"
+            alt="VirtualPostMail logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.scu-social-entrepreneurship.org/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/miller-center-logo-min.png') }}"
+            alt="Miller Center for Social Entrepreneurship logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.redbubble.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Redbubble-logo-min.png') }}"
+            alt="Redbubble logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.airbnb.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Airbnb-logo-min.png') }}"
+            alt="Airbnb logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.surveymonkey.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/SurveyMonkey-logo-min.png') }}"
+            alt="SurveyMonkey logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.appdynamics.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/AppDynamics-logo-min.jpg') }}"
+            alt="AppDynamics logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.indeed.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Indeed-logo-min.png') }}"
+            alt="Indeed logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://scale.ai/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Scale-logo.png') }}"
+            alt="Scale logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.getpostman.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Postman-logo.png') }}"
+            alt="Postman logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://blend.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Blend-logo.png') }}"
+            alt="Blend logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://meraki.cisco.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Cisco-Meraki-logo.jpg') }}"
+            alt="Cisco Meraki logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://branch.io/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Branch-logo.jpg') }}"
+            alt="Branch logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://remix.com" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Remix-logo-min.png') }}"
+            alt="Remix logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.tonal.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Tonal-logo-min.png') }}"
+            alt="Tonal logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.purestorage.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Pure-Storage-logo-min.png') }}"
+            alt="Pure Storage logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.grove.co/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Grove-Collaborative-logo-min.png') }}"
+            alt="Grove Collaborative logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.freenome.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Freenome-logo-min.png') }}"
+            alt="Freenome logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
       </div>
-
-      <div class="row row__center our-supporters" id="supporters">
-          <h1 class="blue-h1">Thank you for your support!</h1>
-          <div class="row">
-            <div class="column centered">
-              <a href="http://sfpl.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/sfpl-logo.jpg') }}"
-                  alt="San Francisco Public Library logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://blog.rackspace.com/the-rackspace-startup-program" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/rackspace-startups-logo.png') }}"
-                  alt="Rackspace Startups logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.stanthonysf.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/st-anthonys.jpg') }}"
-                  alt="St. Anthony Foundation logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.zendesk.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/zendesk-logo-min.png') }}"
-                  alt="Zendesk logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.python.org/psf/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/python-software-foundation-logo.jpg') }}"
-                  alt="Python Software Foundation logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="http://www.kaporcenter.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/kapor-center-for-social-impact-logo.jpg') }}"
-                  alt="Kapor Center for Social Impact logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.scienceexchange.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/scienceexchange_logo.png') }}"
-                  alt="Science Exchange logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.beezwax.net" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/beezwax-logo.png')}}"
-                  alt="Beezwax logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="http://sfpl.org/?pg=0200006301" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/bridge-at-main.jpg') }}"
-                  alt="The Bridge at Main: Learning resources, classes, and people who can help."
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://stripe.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/stripe.png') }}"
-                  alt="Stripe logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://pantheon.io/" target="_blank" rel="noopener noreferrer">
-                  <img src="{{ url_for('static', filename='img/pantheon-logo-min.jpg') }}"
-                  alt="Pantheon.io logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://redfin.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/redfin-logo.png') }}"
-                  alt="Redfin logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://exygy.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/exygy-logo-min.jpg') }}"
-                  alt="Exygy logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.cloverhealth.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/clover-health-logo-min.png') }}"
-                  alt="Clover Health logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://worldwidewomen.co/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/world-wide-women-min.png') }}"
-                  alt="WorldWideWomen logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.moo.com/us/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/moo-logo-min.png') }}"
-                  alt="Moo logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.quantcast.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/quantcast-logo-min.png') }}"
-                  alt="Quantcast logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.ancestry.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/ancestry-logo-min.png') }}"
-                  alt="Ancestry logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.wikimedia.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/wikimedia-foundation-logo-min.png') }}"
-                  alt="Wikimedia Foundation logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://github.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/github-logo-min.png') }}"
-                  alt="GitHub logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.hugeinc.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/huge-logo-min.png') }}"
-                  alt="Huge logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://mixpanel.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/mixpanel-logo-min.png') }}"
-                  alt="Mixpanel logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.rallyhealth.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/rally-health-logo-min.png') }}"
-                  alt="Rally Health logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.techhireoakland.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/TechHire-logo-min.png') }}"
-                  alt="TechHire logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.onelogin.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/onelogin-logo-min.png') }}"
-                  alt="OneLogin logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.agari.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/agari-logo-min.png') }}"
-                  alt="Agari logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.kintone.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/kintone-logo-min.png') }}"
-                  alt="Kintone logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.autonomic.ai/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Autonomic-logo-min.png') }}"
-                  alt="Autonomic logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://mailchimp.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/mailchimp-logo-min.png') }}"
-                  alt="Mailchimp logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://virtualpostmail.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/virtualpostmail-logo-min.png') }}"
-                  alt="VirtualPostMail logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.scu-social-entrepreneurship.org/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/miller-center-logo-min.png') }}"
-                  alt="Miller Center for Social Entrepreneurship logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.redbubble.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Redbubble-logo-min.png') }}"
-                  alt="Redbubble logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.airbnb.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Airbnb-logo-min.png') }}"
-                  alt="Airbnb logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.surveymonkey.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/SurveyMonkey-logo-min.png') }}"
-                  alt="SurveyMonkey logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.appdynamics.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/AppDynamics-logo-min.jpg') }}"
-                  alt="AppDynamics logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.indeed.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Indeed-logo-min.png') }}"
-                  alt="Indeed logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://scale.ai/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Scale-logo.png') }}"
-                  alt="Scale logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.getpostman.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Postman-logo.png') }}"
-                  alt="Postman logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://blend.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Blend-logo.png') }}"
-                  alt="Blend logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://meraki.cisco.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Cisco-Meraki-logo.jpg') }}"
-                  alt="Cisco Meraki logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://branch.io/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Branch-logo.jpg') }}"
-                  alt="Branch logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://remix.com" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Remix-logo-min.png') }}"
-                  alt="Remix logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.tonal.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Tonal-logo-min.png') }}"
-                  alt="Tonal logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.purestorage.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Pure-Storage-logo-min.png') }}"
-                  alt="Pure Storage logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.grove.co/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Grove-Collaborative-logo-min.png') }}"
-                  alt="Grove Collaborative logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-              <a href="https://www.freenome.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Freenome-logo-min.png') }}"
-                  alt="Freenome logo"
-                  class="twenty-percent-width margin-25">
-              </a>
-            </div>
-          </div>
-          <div class="row">
-            <div class="column centered">
-              <a href="https://github.com/gsong" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/George-Song.png') }}"
-                  alt="George Song"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://twitter.com/scott_triglia" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Scott-Triglia.jpg') }}"
-                alt="Scott Triglia"
-                class="ten-percent-width margin-25">
-              </a>
-              <a href="https://www.linkedin.com/in/vwfchan/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Vivien-Chan.jpg') }}"
-                  alt="Vivien Chan"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://twitter.com/avh4" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Aaron-VonderHaar-min.jpg') }}"
-                  alt="Aaron VonderHaar"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://www.linkedin.com/in/ariannawillett/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Arianna-Willett-min.jpg') }}"
-                  alt="Arianna Willett"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://www.linkedin.com/in/bnakamura/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Beth-Nakamura-min.jpg') }}"
-                  alt="Beth Nakamura"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://twitter.com/sharonw" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Sharon-Wong-min.jpg') }}"
-                  alt="Sharon Wong"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://twitter.com/internetross" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Ross-Chapman-min.jpg') }}"
-                  alt="Ross Chapman"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="http://nicolefv.com/" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Nicole-Forsgren-min.jpg') }}"
-                  alt="Nicole Forsgren"
-                  class="ten-percent-width margin-25">
-              </a>
-              <a href="https://twitter.com/jeffiel" target="_blank" rel="noopener noreferrer">
-                <img src="{{ url_for('static', filename='img/Erica-Jeff-Lawson.png') }}"
-                  alt="Erica & Jeff Lawson"
-                  class="ten-percent-width margin-25">
-              </a>
-            </div>
-          </div>
-        </div>
-        <div class="row row__center blue-background a-word-from-supporters" id="a-word">
-          <h2 id="quotes">“The apprentices are so impressive—any one of them would be a great asset. The Bay Area often brags of innovation but it’s Techtonica that delivers.” -Michelle Krejci, Service Engineer Tech Lead at Pantheon</h2>
-            </div>
+    </div>
+    <div class="row">
+      <div class="column centered">
+        <a
+          href="https://github.com/gsong"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/George-Song.png') }}"
+            alt="George Song"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://twitter.com/scott_triglia"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Scott-Triglia.jpg') }}"
+            alt="Scott Triglia"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.linkedin.com/in/vwfchan/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Vivien-Chan.jpg') }}"
+            alt="Vivien Chan"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://twitter.com/avh4"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Aaron-VonderHaar-min.jpg') }}"
+            alt="Aaron VonderHaar"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.linkedin.com/in/ariannawillett/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Arianna-Willett-min.jpg') }}"
+            alt="Arianna Willett"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.linkedin.com/in/bnakamura/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Beth-Nakamura-min.jpg') }}"
+            alt="Beth Nakamura"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://twitter.com/sharonw"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Sharon-Wong-min.jpg') }}"
+            alt="Sharon Wong"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://twitter.com/internetross"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Ross-Chapman-min.jpg') }}"
+            alt="Ross Chapman"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="http://nicolefv.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Nicole-Forsgren-min.jpg') }}"
+            alt="Nicole Forsgren"
+            class="ten-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://twitter.com/jeffiel"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Erica-Jeff-Lawson.png') }}"
+            alt="Erica & Jeff Lawson"
+            class="ten-percent-width margin-25"
+          />
+        </a>
       </div>
+    </div>
+  </div>
+  <div
+    class="row row__center blue-background a-word-from-supporters"
+    id="a-word"
+  >
+    <h2 id="quotes">
+      “The apprentices are so impressive—any one of them would be a great asset.
+      The Bay Area often brags of innovation but it’s Techtonica that delivers.”
+      -Michelle Krejci, Service Engineer Tech Lead at Pantheon
+    </h2>
+  </div>
+</div>
 {% endblock content %}

--- a/templates/mentor.html
+++ b/templates/mentor.html
@@ -1,113 +1,168 @@
-{% extends "base.html" %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Mentoring {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column">
+    <h1 class="blue-h1">Mentor an Apprentice</h1>
+    <p class="justify">
+      Techtonica is a rigorous, six-month training program followed by job
+      placement for Bay Area women and non-binary adults with low incomes. Our
+      apprentices will benefit from the experience, insight, and support of
+      someone who understands their desire to become software engineers and has
+      successfully achieved that goal themselves. To improve our apprentices’
+      probability of success, we pair them with a mentor who can serve in the
+      following roles:
+    </p>
+    <ul>
+      <li>
+        Advisor – Mentors share their professional wisdom, give feedback on
+        projects, and are available to be a sounding board for apprentices’
+        ideas.
+      </li>
+      <li>
+        Role Model – A mentor’s insight into their professional journey helps
+        our apprentices see their own path into a new career.
+      </li>
+      <li>
+        Supporter – Learning to code can be a difficult and frustrating
+        endeavor. It is incredibly important to have a mentor who listens with a
+        sympathetic ear, acknowledges disappointments, and celebrates triumphs.
+      </li>
+    </ul>
+  </div>
+</div>
+<div class="row row__center blue-background">
+  <div class="column">
+    <h3>Benefits to Mentors</h3>
 
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Mentoring
-{% endblock title %}
+    <ul>
+      <li>
+        Techtonica mentors have a direct impact on creating a more diverse,
+        inclusive tech industry.
+      </li>
+      <li>
+        Mentoring builds leadership skills in coaching, counseling, listening,
+        and modeling.
+      </li>
+      <li>
+        Mentors have the opportunity to connect not only with their assigned
+        apprentices, but with other apprentices, Techtonica staff and board
+        members, fellow mentors, as well as other Techtonica supporters.
+      </li>
+    </ul>
 
-{% block content %}
-  	<div class="row row__center about-us">
-	    <div class="column">
-	    	<h1 class="blue-h1">Mentor an Apprentice</h1>
-			<p class="justify">Techtonica is a rigorous, six-month training program followed by job placement for Bay Area women and non-binary adults with low incomes. Our apprentices will benefit from the experience, insight, and support of someone who understands their desire to become software engineers and has successfully achieved that goal themselves. To improve our apprentices’ probability of success, we pair them with a mentor who can serve in the following roles:</p>
-		  	<ul>
-				<li>Advisor – Mentors share their professional wisdom, give feedback on projects, and are available to be a sounding board for apprentices’ ideas.</li>
-				<li>Role Model – A mentor’s insight into their professional journey helps our apprentices see their own path into a new career.</li>
-				<li>Supporter – Learning to code can be a difficult and frustrating endeavor. It is incredibly important to have a mentor who listens with a sympathetic ear, acknowledges disappointments, and celebrates triumphs.</li>
-		  	</ul>
-		</div>
-	</div>
-	<div class="row row__center blue-background">
-		<div class="column">
-		  <h3>Benefits to Mentors</h3>
+    <h3>Eligibility</h3>
+    <p class="justify">
+      In order to best serve our apprentices, mentors must be:
+    </p>
+    <ul>
+      <li>18 years or older</li>
+      <li>Employed as a Software Engineer or in a closely-related field</li>
+      <li>
+        Able to attend most mentor events (at least remotely), including the
+        matching on December 7th, 2019
+      </li>
+    </ul>
+  </div>
+  <div class="column">
+    <a href="{{ url_for('render_sponsor_page') }}">
+      <img
+        src="{{ url_for('static', filename='img/whiteboarding-practice-min.jpg') }}"
+        alt="Two people practicing whiteboarding."
+        class="full-width-img"
+      />
+    </a>
+  </div>
+</div>
+<div class="row row__center">
+  <div class="column">
+    <h3>Roles and Expectations</h3>
+    <table class="mentor" cellpadding="0" cellspacing="0">
+      <tr>
+        <td>Mentors</td>
+        <td>
+          <ul>
+            <li>
+              Provide encouragement, professional advice, and technical
+              guidance.
+            </li>
+            <li>Stay accessible, committed, and engaged with apprentices.</li>
+            <li>
+              Outside of program hours (Monday through Friday from 8:30 to 5:30
+              PM), meet with apprentices in-person or via video call at least
+              two hours per week for the duration of the training (six months)
+              and placement (six months).
+            </li>
+            <li>Respond to apprentice communications within 24 hours.</li>
+            <li>Submit regular reports to program staff.</li>
+            <li>Participate in program assessments as asked.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>Apprentices</td>
+        <td>
+          <ul>
+            <li>
+              Meet with their mentors at least two hours per week for the
+              duration of the training (six months) and placement (six months).
+            </li>
+            <li>Stay accessible, committed, and engaged with mentors.</li>
+            <li>Participate in program assessments.</li>
+          </ul>
+        </td>
+      </tr>
+      <tr>
+        <td>Techtonica</td>
+        <td>
+          <ul>
+            <li>Recruit, select, and match mentors with apprentices.</li>
+            <li>
+              Provide support and resources to facilitate apprentice/mentor
+              relationship.
+            </li>
+          </ul>
+        </td>
+      </tr>
+    </table>
 
-		    <ul>
-				<li>Techtonica mentors have a direct impact on creating a more diverse, inclusive tech industry.</li>
-				<li>Mentoring builds leadership skills in coaching, counseling, listening, and modeling.</li>
-				<li>Mentors have the opportunity to connect not only with their assigned apprentices, but with other apprentices, Techtonica staff and board members, fellow mentors, as well as other Techtonica supporters.</li>
-			</ul>
+    <h3>January 2020 Cohort Timeline</h3>
+    <table class="mentor" cellpadding="0" cellspacing="0">
+      <tr>
+        <td>October 18th - November 15th</td>
+        <td>Mentor applications open</td>
+      </tr>
+      <tr>
+        <td>November 18th - November 25th</td>
+        <td>Mentor interviews</td>
+      </tr>
+      <tr>
+        <td>November 27th</td>
+        <td>Mentor selections</td>
+      </tr>
+      <tr>
+        <td>December 7th</td>
+        <td>Mentor matching and apprentice onboarding</td>
+      </tr>
+      <tr>
+        <td>January - June 2020</td>
+        <td>Techtonica Training</td>
+      </tr>
+      <tr>
+        <td>July - December 2020</td>
+        <td>Support during placement with Techtonica partners</td>
+      </tr>
+    </table>
 
-		    <h3>Eligibility</h3>
-		    <p class="justify">In order to best serve our apprentices, mentors must be:</p>
-		    <ul>
-			  	<li>18 years or older</li>
-				<li>Employed as a Software Engineer or in a closely-related field</li>
-				<li>Able to attend most mentor events (at least remotely), including the matching on December 7th, 2019</li>
-			</ul>
-		</div>
-		<div class="column">
-			<a href="{{ url_for('render_sponsor_page') }}">
-            <img src="{{ url_for('static', filename='img/whiteboarding-practice-min.jpg') }}" alt="Two people practicing whiteboarding." class="full-width-img">
-          </a>
-		</div>
-	</div>
-	<div class="row row__center">
-		<div class="column">
-		  	<h3>Roles and Expectations</h3>
-		 	<table class="mentor" cellpadding=0 cellspacing=0>
-				<tr>
-				    <td>Mentors</td>
-				    <td>
-					    <ul>
-						  <li>Provide encouragement, professional advice, and technical guidance.</li>
-					  	  <li>Stay accessible, committed, and engaged with apprentices.</li>
-						  <li>Outside of program hours (Monday through Friday from 8:30 to 5:30 PM), meet with apprentices in-person or via video call at least two hours per week for the duration of the training (six months) and placement (six months).</li>
-						  <li>Respond to apprentice communications within 24 hours.</li>
-						  <li>Submit regular reports to program staff.</li>
-						  <li>Participate in program assessments as asked.</li>
-						</ul>
-				  </td>
-			    </tr>
-				<tr>
-				  	<td>Apprentices</td>
-				  	<td>
-						<ul>
-						  <li>Meet with their mentors at least two hours per week for the duration of the training (six months) and placement (six months).</li>
-						  <li>Stay accessible, committed, and engaged with mentors.</li>
-						  <li>Participate in program assessments.</li>
-						</ul>
-				  	</td>
-			    </tr>
-				<tr>
-				  	<td>Techtonica</td>
-				  	<td>
-						<ul>
-						  <li>Recruit, select, and match mentors with apprentices.</li>
-						  <li>Provide support and resources to facilitate apprentice/mentor relationship.</li>
-						</ul>
-				  	</td>
-			    </tr>
-	  	  	</table>
-
-		    <h3>January 2020 Cohort Timeline</h3>
-		    <table class="mentor" cellpadding=0 cellspacing=0>
-				<tr>
-				    <td>October 18th - November 15th</td>
-			  	    <td>Mentor applications open</td>
-			    </tr>
-			    <tr>
-				    <td>November 18th - November 25th</td>
-			  	    <td>Mentor interviews</td>
-			    </tr>
-			    <tr>
-				    <td>November 27th</td>
-			  	    <td>Mentor selections</td>
-			    </tr>
-				<tr>
-				    <td>December 7th</td>
-			  	    <td>Mentor matching and apprentice onboarding</td>
-			    </tr>
-				<tr>
-				    <td>January - June 2020</td>
-			  	    <td>Techtonica Training</td>
-			    </tr>
-				<tr>
-				    <td>July - December 2020</td>
-				    <td>Support during placement with Techtonica partners</td>
-			    </tr>
-		    </table>
-
-	      	<p class="justify">If this sounds like a commitment that you can make, please apply now!</p>
-	      	<a href="https://docs.google.com/forms/d/1o2sd2UncpYCybysLL62sWQludOgByshl2T9kUrKDnOI/viewform" class="sponsor" id="orange-button" target="_blank" >Apply to become a mentor</a>
-	    </div>
-	</div>
+    <p class="justify">
+      If this sounds like a commitment that you can make, please apply now!
+    </p>
+    <a
+      href="https://docs.google.com/forms/d/1o2sd2UncpYCybysLL62sWQludOgByshl2T9kUrKDnOI/viewform"
+      class="sponsor"
+      id="orange-button"
+      target="_blank"
+      >Apply to become a mentor</a
+    >
+  </div>
+</div>
 {% endblock content %}

--- a/templates/news.html
+++ b/templates/news.html
@@ -1,214 +1,831 @@
-{% extends "base.html" %}
-
-{% block title %}
-	Techtonica: Bridging the Tech Gap
-{% endblock title %}
-
-{% block content %}
-<div class="row row__center blue-background" id="news-title" style="padding:0;">
-	<h1>In The News</h1>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block content %}
+<div
+  class="row row__center blue-background"
+  id="news-title"
+  style="padding: 0;"
+>
+  <h1>In The News</h1>
 </div>
 <div class="column centered">
-	<h2>News from Techtonica</h2>
-	<!-- N.B. collapsible expects that button class collapsible live at the same depth as div class collapsible-content. -->
-	<ul class="hidden-bullets">
-			<li>
-			<button class="collapsible">Rally Health Partners with Techtonica to Support Engineering Apprentice Program</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">SAN FRANCISCO, November 22nd, 2019 -- Rally Health, a digital healthcare platform, has again sponsored two Techtonica apprentices for six months of intensive JavaScript training followed by placement. 
-						Rally Health joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement. The partnership sponsors are crucial to the continuation of Techtonica’s program, providing the funds needed for one apprentice to complete their training before being matched for job placement with the company.
-						“The opportunities in digital health are all about helping people and improving access to tools for care,” said Techtonica Founder & CEO, Michelle Glauser. “It’s exactly the type of work our apprentices will thrive in, and we’re thrilled to have Rally Health open that door to another of our graduates.”
-						Techtonica’s full-time training for its apprentices ends in December and Rally will welcome two apprentices for a six-month work placement afterward. 
-						</p>
-				<p class="press-release-bold">About Rally Health</p>
-				<p>Rally Health, Inc. is a consumer-centric digital health company that makes it easy for individuals to take charge of their health and collaborates with health plans, health care providers, and employers to engage consumers. The company’s flagship offering is Rally®, a leading digital health platform that delivers web and mobile solutions to helgmp people manage their employee benefits, health and well-being, and health care needs. Nearly 55 million consumers have access to the Rally platform through more than 200,000 employers, and health plans, including UnitedHealthcare, BlueCross BlueShield of South Carolina, and Health Alliance. With seven offices across the U.S., Rally Health has been working since 2010 to transform the consumer health industry. Rally Health is part of the Optum business of UnitedHealth Group. For more information, please visit www.RallyHealth.com
-			</div>
-		</li>
-				<li>
-		<li>
-		    <button class="collapsible">Indeed Continues its Support of Techtonica’s Apprenticeship Program</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">The leading job site commits to another Advocate-Level sponsorship of the organization's latest cohort of apprentices</p>
-				<p>SAN FRANCISCO, February 13th, 2020--Techtonica announced today that Indeed, the world’s number one job site, is returning as an official sponsor of Bay Area nonprofit, Techtonica. Indeed leads a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“Indeed has become an integral sponsor for Techtonica, providing access to mentors, resources, and office space in San Francisco,.” said Techtonica Founder & CEO, Michelle Glauser. “We’re thrilled to have their continued support for our apprentices.”</p>
-			    <p>“Indeed is excited to continue to work with Techtonica and their latest cohort of apprentices,” said Doug Gray, SVP of Engineering at Indeed. “We look forward to mentoring this new group as they embark on their journey into the technology industry.”</p>
-				<p>As with the Techtonica cohort Indeed previously sponsored, a portion of the graduates will be offered employment at the end of their six months of full-time training.</p>
-				<p class="press-release-bold">About Indeed</p>
-			    <p>More people find jobs on Indeed than anywhere else. Indeed is the #1 job site in the world1 and allows job seekers to search millions of jobs on the web or mobile in over 60 countries and 28 languages. More than 250 million people each month search for jobs, post resumes, and research companies on Indeed,2 and Indeed delivers 3X more hires than any other job site.3 For more information, visit indeed.com.
-						
-				<ol>
-				<li>ComScore, March 2019</li>
-				<li>Google Analytics, Unique Visitors, September 2018</li>
-				<li>SilkRoad Technology Source of Hire Report, 2018</li>
-				</ol>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Blend Sponsors Techtonica’s 2019 Apprenticeship Program</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Blend Partners with Techtonica to Support Engineering Apprentice Program</p>
-				<p>SAN FRANCISCO, November 12th, 2019--Techtonica is pleased to announce that <a href="https://blend.com/" target="_blank" rel="noopener noreferrer">Blend</a>, a digital lending platform, has sponsored two of Techtoncia’s apprentices for six months of intensive JavaScript training followed by placement. This is the second cohort Techtonica has run for 2019, with the first apprenticeship class having graduated and been placed with companies in June.</p>
-				<p>Blend joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement. The partnership sponsors are crucial to the continuation of Techtonica’s program, providing the funds needed for one apprentice to complete their training before being matched for job placement with the company.</p>
-				<p>“Blend was a natural fit for our partner-level sponsorships as both sides are dedicated to improving accessibility to needed resources, whether that’s financial or technological education,” said Techtonica Founder & CEO, Michelle Glauser. “We’re excited about the opportunities ahead of the apprentice that gets matched with Blend, and we’re beyond thrilled to have them on board with us at Techtonica.”</p>
-				<p>“Our aspiration is to be the equitable employer of the future, and we recognize that we must invest in the development of future talent in order to achieve that goal,” said Ulysses Smith, Diversity, Inclusion, and Belonging Leader at Blend. “We also have community investment and social impact as a core pillar of our diversity, inclusion and belonging strategy. We invest in the local communities where we are present and use our purchasing power to provide economic stability and opportunity. Techtonica is a partner that greatly supports both of these elements, and we are proud to partner with an organization that is leading the charge for equity for local women and nonbinary folks.”</p>
-				<p>Techtonica’s full-time training for its apprentices ends in December and Blend will welcome two apprentices for a six-month work placement afterward.</p>
-				<p class="press-release-bold">About Blend</p>
-				<p>Blend makes the process of getting a loan simpler, faster, and safer. With its Digital Lending Platform, Blend helps financial institutions including Wells Fargo and U.S. Bank increase productivity and deliver exceptional customer experiences. The company regularly processes over $2 billion in mortgages and consumer loans daily, helping millions of consumers get into homes and gain access to the capital they need to lead better lives. To learn more, visit blend.com.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Leading Job Site Sponsors Techtonica’s 2019 Apprenticeship Program</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Indeed becomes Techtonica’s Advocate-level sponsor for its latest cohort</p>
-				<p>SAN FRANCISCO, CA March 13th, 2019--Techtonica announced today that <a href="https://www.indeed.com" target="_blank" rel="noopener noreferrer">Indeed</a>, the world’s number one job site, is an official sponsor of Bay Area nonprofit, Techtonica. Indeed joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“Indeed is sponsoring five of the participants of our latest cohort, providing the group with resources, including access to mentors, on-site resources, and desk space in the company’s San Francisco office, for the duration of their training,” said Techtonica Founder & CEO, Michelle Glauser.</p>
-				<p>"Indeed is committed to increasing workplace inclusion, not only as an employer but as a global company that serves a diverse group of job seekers around the world,” said Doug Gray, SVP of Engineering at Indeed. “While we recognize there is not one solution, we believe partnering with organizations that are focused on creating a diverse pipeline of talent, like Techtonica, is one of the ways we can support the development of more inclusive workplaces.”</p>
-				<p>Upon completion of Techtonica’s six months of full-time training, five program graduates will be offered employment at Indeed.</p>
-				<p class="press-release-bold">About Indeed</p>
-				<p>Indeed is the #1 job site in the world with over 250 million unique visitors every month (ComScore Total Visits, March 2018 and  Google Analytics, Unique Visitors, September 2018). Indeed strives to put job seekers first, giving them free access to search for jobs, post resumes, and research companies. Every day, we connect millions of people to new opportunities.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Techtonica announces Quantcast as latest supporter</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Quantcast becomes Techtonica’s newest advocate-level sponsor for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA March 6th, 2019--<a href="https://www.quantcast.com" target="_blank" rel="noopener noreferrer">Quantcast</a> has become a sponsor of a Bay Area nonprofit, Techtonica. Quantcast joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“We are thrilled to have Quantcast join us as an advocate sponsor,” said Techtonica Founder & CEO, Michelle Glauser. “They’ve hosted our events before and this is the next step of support.”</p>
-				<p>With a mission to build the audience platform to radically simplify advertising on the open internet, Quantcast applies machine learning technology to its unique data to help publishers and advertisers more effectively engage audiences online.</p>
-				<p><a href="https://www.linkedin.com/in/sandramcdevitt/" target="_blank" rel="noopener noreferrer">Sandra McDevitt</a>, Chief People Officer at Quantcast, commented, “Quantcast is committed to creating an inclusive and diverse environment where everyone can confidently be their authentic self. Central to that is ensuring we’re bringing in people from all sorts of backgrounds. The work Michelle and the team at Techtonica are doing aligns very closely with our values as our organization, and we’re delighted to support this important initiative.”</p>
-				<p>Techtonica’s six months of full-time training for its apprentices ends in June and one lucky individual will start working at Quantcast thereafter.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">AppDynamics becomes sponsor of Techtonica</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">AppDynamics becomes Techtonica’s newest advocate-level sponsor for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA Feb. 25, 2019--<a href="https://www.appdynamics.com" target="_blank" rel="noopener noreferrer">AppDynamics</a> joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“We are so excited to have AppDynamics join us as an advocate sponsor for our first 2019 cohort of software engineering apprentices,” said Techtonica Founder & CEO, Michelle Glauser. “Their work in application performance management provides a unique opportunity for our apprentices.”</p>
-				<p>“We are looking forward to mentoring a great group of apprentices and sharing our experiences in the software industry with them,” said Albert Chang, Sr. Engineering Manager.</p>
-				<p>Techtonica’s six months of full-time technical training ends in June 2019, at which time a graduate of the program will begin working at AppDynamics.</p>
-				<p class="press-release-bold">About AppDynamics</p>
-				<p>AppDynamics is the Application Intelligence company. With AppDynamics, enterprises have real-time insights into application performance, user performance and business performance so they can move faster in an increasingly sophisticated, software-driven world. AppDynamics’ integrated suite of applications is built on its innovative, enterprise-grade App iQ Platform that enables its customers to make faster decisions that enhance customer engagement and improve operational and business performance. AppDynamics is uniquely positioned to enable enterprises to accelerate their digital transformations by actively monitoring, analyzing and optimizing complex application environments at scale.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Techtonica announces sponsorship by SurveyMonkey</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">SurveyMonkey becomes Techtonica’s newest advocate-level sponsor for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA Feb. 20, 2019--Techtonica happily announces that <a href="https://www.surveymonkey.com" target="_blank" rel="noopener noreferrer">SurveyMonkey</a> has become a sponsor. SurveyMonkey will be joining a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“It is fantastic to have SurveyMonkey become an advocate sponsor for our participants,” said Techtonica Founder & CEO, Michelle Glauser. “Our advocate sponsors provide the support needed for us to offer six months of full-time training with living stipends and laptops to participants, and at the end of the six months, sponsors have new employees who can add their unique perspectives—as Bay Area women and non-binary adults with low-income backgrounds—to the team.”</p>
-				<p>“We are focused on diversity and inclusion as a company and as an engineering team, which means building a diverse workforce, and creating an inclusive environment where every person feels comfortable and empowered,” said Robin Ducot, SurveyMonkey CTO. “Techtonica’s apprenticeship aligns perfectly with our values, and we are thrilled to partner with them in helping underrepresented, underprivileged individuals get the job skills and support they need to succeed in software engineering.”</p>
-				<p>Techtonica’s six months of full-time training for its apprentices ends in June and one lucky individual will start working at SurveyMonkey thereafter.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Pantheon announces continued support for Techtonica</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Pantheon once again becomes a Techtonica advocate-level sponsor, this time for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA Feb. 14, 2019--<a href="https://pantheon.io">Pantheon</a>, Techtonica’s first-ever advocate-level hiring sponsor has returned for the 2019 year to sponsor another class. Pantheon leads a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“We are thrilled to have Pantheon on board again,” said Techtonica Founder & CEO, Michelle Glauser. “They were early believers in our mission to bridge the tech gap and we’re looking forward to seeing what new opportunities we can create together. Our first graduate placed with Pantheon has truly thrived, so there’s great potential in our continued partnership.”</p>
-				<p>“The Bay Area often brags of innovation but it’s the Techtonica program that delivers,” said Pantheon’s Service Engineer Tech Lead, Michelle Krejci. “We plan to continue to grow our team of passionate, creative, collaborative engineers with the graduates of Techtonica. We are delighted to see so many tech companies that we admire lining up now as well.”</p>
-				<p>Techtonica’s six months of full-time training for its apprentices ends in June of this year and one lucky individual will start a three-month job placement at Pantheon thereafter. </p>
-				<p class="press-release-bold">About Pantheon</p>
-				<p>Pantheon is a website operations platform for Drupal and WordPress, running more than 200,000 sites in the cloud and serving over 10 billion pageviews a month. Pantheon's multitenant, container-based platform enables web teams to manage all of their websites from a single dashboard. Our secret sauce? Our passionate, creative, collaborative team. Learn more at <a href="https://pantheon.io">pantheon.io</a>.
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Autonomic Partners with Techtonica to Help Women and Non-Binary Adults Embark on Silicon Valley Careers</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Partnership supports an apprenticeship program where Techtonica graduates intern with Autonomic’s engineering department and help create the future of mobility.</p>
-				<p>SAN FRANCISCO, Calif. January 31, 2019 --- Autonomic, creators of the Transportation Mobility Cloud (TMC), the first open, cloud-based platform for connected vehicles, announce its sponsorship of Techtonica’s apprenticeship program. Techtonica, a non-profit organization focused on bridging Silicon Valley’s large gap in workforce diversity, has created an apprenticeship program that strives to bridge this gap by assisting women and non-binary adults with low incomes to break into the high-tech workforce via skill-building boot camps, job placement, and real-world mentorship.</p>
-				<p>Through its apprenticeship program, Techtonica takes aim at structural and social obstacles to obtaining and succeeding in Silicon Valley careers of women and non-binary adults of low-income with a six-month bootcamp that extends into job placement and ongoing mentorship. Techtonica apprentices are chosen from an applicant pool which undergoes a rigorous application process that includes HTML/CSS workshops, a JavaScript workshop, a code challenge, a long application, pairing, and interviews by staff and board members. Underscoring the demand for programs such as this, Techtonica accepts approximately 8% of its applicants to each of its apprenticeship cohorts. Successful applicants receive living stipends, laptops, and more than 950 hours of full-time, project-based, collaborative training on HTML, CSS, and JavaScript.
-				<p>“It is absolutely essential that traditionally marginalized groups have direct access to job-placement programs and mentorship if we want to change things,” explained Techtonica Founder & CEO, Michelle Glauser. “Autonomic clearly understands this and, since their engineering team is working on some of the most interesting challenges in transportation today, we’re thrilled to help them move mobility forward with our graduates.”</p>
-				<p>This summer, a graduate from Techtonica’s apprenticeship program will join Autonomic’s engineering team in Palo Alto and have the opportunity to contribute directly to the TMC platform. The TMC connects the disparate elements of the mobility ecosystem -- including connected vehicles, mass transit, city infrastructure, and service providers -- to orchestrate a safer, more efficient, and sustainable transportation network. The brand-agnostic platform is the first to unite the different parties involved in creating next-generation transportation services with the goal of transforming how people move around cities.</p>
-				<p>“Techtonica has created an effective and laudable program to help those who are often overlooked in the workforce, and especially in the tech industry,” remarked Gavin Sherry, CEO of Autonomic. “We are proud to be able to support their efforts and are pleased to welcome their graduates to Autonomic.”</p>
-				<p>The news follows an eventful 2018 for Autonomic. Beginning in February 2018, with their acquisition by Ford Smart Mobility, LLC, Autonomic announced a series of partnerships across the transportation ecosystem, including the provision of routing and mapping services for any vehicle connected to the TMC via rideOS integration, and the planned ability for fleet managers to connect their vehicles anywhere in the world via low-cost satellites via Swarm Technologies. Autonomic also expanded globally by partnering with Alibaba Cloud to bring TMC’s benefits to the Chinese market.</p>
-				<p class="press-release-bold">About Autonomic</p>
-				<p>Autonomic is the first open cloud platform for connected vehicles, powering the automotive digital ecosystem. As the only company to create the world’s foremost transportation and mobility platform for connected vehicles -- called the Transportation Mobility Cloud -- Autonomic gives car makers and developers the infrastructure to build customer experiences for connected vehicles.</p>
-				<p>Founded in 2016, the Autonomic team hails from companies like Xtreme Labs - acquired by Pivotal - and Amazon. Together, they architected large-scale cloud computing platforms and built distribution databases for well-known consumer mobile apps such as Tinder and Facebook. The company is set to usher in a new era of connected vehicles and transform how people move around cities. To learn more about Autonomic, visit <a href="https://autonomic.ai" target="_blank" rel="noopener noreferrer">autonomic.ai</a>.</p>
-				<p class="press-release-bold">About Techtonica</p>
-				<p>Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship program based in San Francisco that partners with tech companies to provide free, intensive tech training and job placement specifically for Bay Area women and non-binary adults who have low incomes. Learn more at techtonica.org.</p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Agari announces support for Techtonica</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Agari becomes Techtonica’s newest advocate-level sponsor for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA Jan. 15th, 2019---Agari is happy to announce they are becoming a sponsor of Bay Area nonprofit, Techtonica. Agari joins a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“We are so excited to have Agari join us as an advocate sponsor for our next cohort that will be starting in January,” said Techtonica Founder & CEO, Michelle Glauser. “Agari’s work in cybersecurity and email protection provides a unique opportunity for our future apprentices.”</p>
-				<p>“We believe that optimizing our hiring process to find engineers who enhance our community over solely looking for ‘rock star’ individuals leads to a better outcome and a more diverse technology workforce,” said Chris Haag, Senior Director of Engineering at Agari. “We're supporting Techtonica's mission to provide training and support to women and non-binary adults with low incomes and look forward to supporting the 2019 cohort through their classes and internship.”</p>
-				<p>Techtonica’s six months of full-time technical training ends in June 2019, at which time a graduate of the program will begin working at Agari.</p>
-				<p class="press-release-bold">About Techtonica</p>
-				<p>Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship program based in San Francisco that partners with tech companies to provide free, intensive tech training and job placement specifically for Bay Area women and non-binary adults who have low incomes. Learn more at <a href="https://techtonica.org/" target="_blank" rel="noopener noreferrer">techtonica.org</a>.</p>
-				<p class="press-release-bold">About Agari</p>
-				<p>Agari is the only cloud-native solution that uses predictive AI to stop advanced email attacks. Winner of Best Email Security Solution by SC Magazine in 2018, the Agari Email Trust Platform™ prevents ransomware, ATO, phishing, BEC and other identity deception attacks, restoring trust to digital channels for businesses, governments, and consumers worldwide. Learn more at <a href="https://www.agari.com" target="_blank" rel="noopener noreferrer">www.agari.com</a>.</p>
-				<p><a href="https://www.agari.com" target="_blank" rel="noopener noreferrer"><img src="{{ url_for('static', filename='img/agari-logo-min.png') }}" alt="Agari logo" class="resize-200px"></a></p>
-				<p>Media Contact:</p>
-				<p>Clinton Karr</p>
-				<p><a href="mailto:agari@summitstrategygroup.net">agari@summitstrategygroup.net</a></p>
-				<p><a href="tel:415-993-1010">(415) 993-1010</a></p>
-			</div>
-		</li>
-		<li>
-			<button class="collapsible">Kintone announces support for Techtonica</button>
-			<div class="collapsible-content justify">
-				<p class="press-release-summary">Kintone becomes Techtonica’s newest advocate-level sponsor for the 2019 apprenticeship.</p>
-				<p>SAN FRANCISCO, CA Dec. 17, 2018---Kintone proudly announces becoming a sponsor of Bay Area nonprofit, Techtonica. Kintone will be joining a growing group of Bay Area companies dedicated to Techtonica’s mission of empowering local women and non-binary adults with low incomes through tech training and job placement.</p>
-				<p>“We are thrilled to have Kintone join us as an advocate sponsor for our next cohort that will be starting in January,” said Techtonica Founder & CEO, Michelle Glauser.</p>
-				<p>“We’re thrilled to support Techtonica,” said Kintone CEO Dave Landa. “As a cloud-based database platform company on a mission to make teamwork better globally, this is an excellent opportunity to affirm our commitment to diversity and inclusion of underserved communities in the tech industry.”</p>
-				<p>Techtonica’s six months of full-time training for its apprentices ends in June and one lucky individual will start working at Kintone thereafter.</p>
-				<p class="press-release-bold">About Techtonica</p>
-				<p>Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship program based in San Francisco that partners with tech companies to provide free, intensive tech training and job placement specifically for Bay Area women and non-binary adults who have low incomes. Learn more at <a href="https://techtonica.org/" target="_blank" rel="noopener noreferrer">techtonica.org</a>.</p>
-				<p class="press-release-bold">About Kintone</p>
-				<p>San Francisco-based Kintone is making teamwork better with its no-code application platform that provides organizations with a customizable workspace that integrates multiple data sources for deeper insight into business processes. Kintone eliminates the cost and maintenance requirements of traditional off-the-shelf applications while dramatically increasing team and workflow efficiency. More than 10,000 companies have built, deployed and use over 500,000 applications on Kintone. Kintone is provided by Cybozu Inc, a Tokyo-based public company founded in 1997. Both Kintone and Cybozu are designated as great workplaces by Great Place to Work, a global authority on high performing workplace cultures. For more information, please visit <a href="https://www.kintone.com/" target="_blank" rel="noopener noreferrer">https://www.kintone.com/</a></p>
-				<p><a href="https://www.kintone.com/" target="_blank" rel="noopener noreferrer"><img src="{{ url_for('static', filename='img/kintone-logo-min.png') }}" alt="Kintone logo" class="resize-200px"></a></p>
-			</div>
-		</li>
-	</ul>
+  <h2>News from Techtonica</h2>
+  <!-- N.B. collapsible expects that button class collapsible live at the same depth as div class collapsible-content. -->
+  <ul class="hidden-bullets">
+    <li>
+      <button class="collapsible">
+        Rally Health Partners with Techtonica to Support Engineering Apprentice
+        Program
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          SAN FRANCISCO, November 22nd, 2019 -- Rally Health, a digital
+          healthcare platform, has again sponsored two Techtonica apprentices
+          for six months of intensive JavaScript training followed by placement.
+          Rally Health joins a growing group of Bay Area companies dedicated to
+          Techtonica’s mission of empowering local women and non-binary adults
+          with low incomes through tech training and job placement. The
+          partnership sponsors are crucial to the continuation of Techtonica’s
+          program, providing the funds needed for one apprentice to complete
+          their training before being matched for job placement with the
+          company. “The opportunities in digital health are all about helping
+          people and improving access to tools for care,” said Techtonica
+          Founder & CEO, Michelle Glauser. “It’s exactly the type of work our
+          apprentices will thrive in, and we’re thrilled to have Rally Health
+          open that door to another of our graduates.” Techtonica’s full-time
+          training for its apprentices ends in December and Rally will welcome
+          two apprentices for a six-month work placement afterward.
+        </p>
+        <p class="press-release-bold">About Rally Health</p>
+        <p>
+          Rally Health, Inc. is a consumer-centric digital health company that
+          makes it easy for individuals to take charge of their health and
+          collaborates with health plans, health care providers, and employers
+          to engage consumers. The company’s flagship offering is Rally®, a
+          leading digital health platform that delivers web and mobile solutions
+          to helgmp people manage their employee benefits, health and
+          well-being, and health care needs. Nearly 55 million consumers have
+          access to the Rally platform through more than 200,000 employers, and
+          health plans, including UnitedHealthcare, BlueCross BlueShield of
+          South Carolina, and Health Alliance. With seven offices across the
+          U.S., Rally Health has been working since 2010 to transform the
+          consumer health industry. Rally Health is part of the Optum business
+          of UnitedHealth Group. For more information, please visit
+          www.RallyHealth.com
+        </p>
+      </div>
+    </li>
+    <li></li>
+    <li>
+      <button class="collapsible">
+        Indeed Continues its Support of Techtonica’s Apprenticeship Program
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          The leading job site commits to another Advocate-Level sponsorship of
+          the organization's latest cohort of apprentices
+        </p>
+        <p>
+          SAN FRANCISCO, February 13th, 2020--Techtonica announced today that
+          Indeed, the world’s number one job site, is returning as an official
+          sponsor of Bay Area nonprofit, Techtonica. Indeed leads a growing
+          group of Bay Area companies dedicated to Techtonica’s mission of
+          empowering local women and non-binary adults with low incomes through
+          tech training and job placement.
+        </p>
+        <p>
+          “Indeed has become an integral sponsor for Techtonica, providing
+          access to mentors, resources, and office space in San Francisco,.”
+          said Techtonica Founder & CEO, Michelle Glauser. “We’re thrilled to
+          have their continued support for our apprentices.”
+        </p>
+        <p>
+          “Indeed is excited to continue to work with Techtonica and their
+          latest cohort of apprentices,” said Doug Gray, SVP of Engineering at
+          Indeed. “We look forward to mentoring this new group as they embark on
+          their journey into the technology industry.”
+        </p>
+        <p>
+          As with the Techtonica cohort Indeed previously sponsored, a portion
+          of the graduates will be offered employment at the end of their six
+          months of full-time training.
+        </p>
+        <p class="press-release-bold">About Indeed</p>
+        <p>
+          More people find jobs on Indeed than anywhere else. Indeed is the #1
+          job site in the world1 and allows job seekers to search millions of
+          jobs on the web or mobile in over 60 countries and 28 languages. More
+          than 250 million people each month search for jobs, post resumes, and
+          research companies on Indeed,2 and Indeed delivers 3X more hires than
+          any other job site.3 For more information, visit indeed.com.
+        </p>
+
+        <ol>
+          <li>ComScore, March 2019</li>
+          <li>Google Analytics, Unique Visitors, September 2018</li>
+          <li>SilkRoad Technology Source of Hire Report, 2018</li>
+        </ol>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Blend Sponsors Techtonica’s 2019 Apprenticeship Program
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Blend Partners with Techtonica to Support Engineering Apprentice
+          Program
+        </p>
+        <p>
+          SAN FRANCISCO, November 12th, 2019--Techtonica is pleased to announce
+          that
+          <a href="https://blend.com/" target="_blank" rel="noopener noreferrer"
+            >Blend</a
+          >, a digital lending platform, has sponsored two of Techtoncia’s
+          apprentices for six months of intensive JavaScript training followed
+          by placement. This is the second cohort Techtonica has run for 2019,
+          with the first apprenticeship class having graduated and been placed
+          with companies in June.
+        </p>
+        <p>
+          Blend joins a growing group of Bay Area companies dedicated to
+          Techtonica’s mission of empowering local women and non-binary adults
+          with low incomes through tech training and job placement. The
+          partnership sponsors are crucial to the continuation of Techtonica’s
+          program, providing the funds needed for one apprentice to complete
+          their training before being matched for job placement with the
+          company.
+        </p>
+        <p>
+          “Blend was a natural fit for our partner-level sponsorships as both
+          sides are dedicated to improving accessibility to needed resources,
+          whether that’s financial or technological education,” said Techtonica
+          Founder & CEO, Michelle Glauser. “We’re excited about the
+          opportunities ahead of the apprentice that gets matched with Blend,
+          and we’re beyond thrilled to have them on board with us at
+          Techtonica.”
+        </p>
+        <p>
+          “Our aspiration is to be the equitable employer of the future, and we
+          recognize that we must invest in the development of future talent in
+          order to achieve that goal,” said Ulysses Smith, Diversity, Inclusion,
+          and Belonging Leader at Blend. “We also have community investment and
+          social impact as a core pillar of our diversity, inclusion and
+          belonging strategy. We invest in the local communities where we are
+          present and use our purchasing power to provide economic stability and
+          opportunity. Techtonica is a partner that greatly supports both of
+          these elements, and we are proud to partner with an organization that
+          is leading the charge for equity for local women and nonbinary folks.”
+        </p>
+        <p>
+          Techtonica’s full-time training for its apprentices ends in December
+          and Blend will welcome two apprentices for a six-month work placement
+          afterward.
+        </p>
+        <p class="press-release-bold">About Blend</p>
+        <p>
+          Blend makes the process of getting a loan simpler, faster, and safer.
+          With its Digital Lending Platform, Blend helps financial institutions
+          including Wells Fargo and U.S. Bank increase productivity and deliver
+          exceptional customer experiences. The company regularly processes over
+          $2 billion in mortgages and consumer loans daily, helping millions of
+          consumers get into homes and gain access to the capital they need to
+          lead better lives. To learn more, visit blend.com.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Leading Job Site Sponsors Techtonica’s 2019 Apprenticeship Program
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Indeed becomes Techtonica’s Advocate-level sponsor for its latest
+          cohort
+        </p>
+        <p>
+          SAN FRANCISCO, CA March 13th, 2019--Techtonica announced today that
+          <a
+            href="https://www.indeed.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Indeed</a
+          >, the world’s number one job site, is an official sponsor of Bay Area
+          nonprofit, Techtonica. Indeed joins a growing group of Bay Area
+          companies dedicated to Techtonica’s mission of empowering local women
+          and non-binary adults with low incomes through tech training and job
+          placement.
+        </p>
+        <p>
+          “Indeed is sponsoring five of the participants of our latest cohort,
+          providing the group with resources, including access to mentors,
+          on-site resources, and desk space in the company’s San Francisco
+          office, for the duration of their training,” said Techtonica Founder &
+          CEO, Michelle Glauser.
+        </p>
+        <p>
+          "Indeed is committed to increasing workplace inclusion, not only as an
+          employer but as a global company that serves a diverse group of job
+          seekers around the world,” said Doug Gray, SVP of Engineering at
+          Indeed. “While we recognize there is not one solution, we believe
+          partnering with organizations that are focused on creating a diverse
+          pipeline of talent, like Techtonica, is one of the ways we can support
+          the development of more inclusive workplaces.”
+        </p>
+        <p>
+          Upon completion of Techtonica’s six months of full-time training, five
+          program graduates will be offered employment at Indeed.
+        </p>
+        <p class="press-release-bold">About Indeed</p>
+        <p>
+          Indeed is the #1 job site in the world with over 250 million unique
+          visitors every month (ComScore Total Visits, March 2018 and Google
+          Analytics, Unique Visitors, September 2018). Indeed strives to put job
+          seekers first, giving them free access to search for jobs, post
+          resumes, and research companies. Every day, we connect millions of
+          people to new opportunities.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Techtonica announces Quantcast as latest supporter
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Quantcast becomes Techtonica’s newest advocate-level sponsor for the
+          2019 apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA March 6th, 2019--<a
+            href="https://www.quantcast.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Quantcast</a
+          >
+          has become a sponsor of a Bay Area nonprofit, Techtonica. Quantcast
+          joins a growing group of Bay Area companies dedicated to Techtonica’s
+          mission of empowering local women and non-binary adults with low
+          incomes through tech training and job placement.
+        </p>
+        <p>
+          “We are thrilled to have Quantcast join us as an advocate sponsor,”
+          said Techtonica Founder & CEO, Michelle Glauser. “They’ve hosted our
+          events before and this is the next step of support.”
+        </p>
+        <p>
+          With a mission to build the audience platform to radically simplify
+          advertising on the open internet, Quantcast applies machine learning
+          technology to its unique data to help publishers and advertisers more
+          effectively engage audiences online.
+        </p>
+        <p>
+          <a
+            href="https://www.linkedin.com/in/sandramcdevitt/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >Sandra McDevitt</a
+          >, Chief People Officer at Quantcast, commented, “Quantcast is
+          committed to creating an inclusive and diverse environment where
+          everyone can confidently be their authentic self. Central to that is
+          ensuring we’re bringing in people from all sorts of backgrounds. The
+          work Michelle and the team at Techtonica are doing aligns very closely
+          with our values as our organization, and we’re delighted to support
+          this important initiative.”
+        </p>
+        <p>
+          Techtonica’s six months of full-time training for its apprentices ends
+          in June and one lucky individual will start working at Quantcast
+          thereafter.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        AppDynamics becomes sponsor of Techtonica
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          AppDynamics becomes Techtonica’s newest advocate-level sponsor for the
+          2019 apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA Feb. 25, 2019--<a
+            href="https://www.appdynamics.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            >AppDynamics</a
+          >
+          joins a growing group of Bay Area companies dedicated to Techtonica’s
+          mission of empowering local women and non-binary adults with low
+          incomes through tech training and job placement.
+        </p>
+        <p>
+          “We are so excited to have AppDynamics join us as an advocate sponsor
+          for our first 2019 cohort of software engineering apprentices,” said
+          Techtonica Founder & CEO, Michelle Glauser. “Their work in application
+          performance management provides a unique opportunity for our
+          apprentices.”
+        </p>
+        <p>
+          “We are looking forward to mentoring a great group of apprentices and
+          sharing our experiences in the software industry with them,” said
+          Albert Chang, Sr. Engineering Manager.
+        </p>
+        <p>
+          Techtonica’s six months of full-time technical training ends in June
+          2019, at which time a graduate of the program will begin working at
+          AppDynamics.
+        </p>
+        <p class="press-release-bold">About AppDynamics</p>
+        <p>
+          AppDynamics is the Application Intelligence company. With AppDynamics,
+          enterprises have real-time insights into application performance, user
+          performance and business performance so they can move faster in an
+          increasingly sophisticated, software-driven world. AppDynamics’
+          integrated suite of applications is built on its innovative,
+          enterprise-grade App iQ Platform that enables its customers to make
+          faster decisions that enhance customer engagement and improve
+          operational and business performance. AppDynamics is uniquely
+          positioned to enable enterprises to accelerate their digital
+          transformations by actively monitoring, analyzing and optimizing
+          complex application environments at scale.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Techtonica announces sponsorship by SurveyMonkey
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          SurveyMonkey becomes Techtonica’s newest advocate-level sponsor for
+          the 2019 apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA Feb. 20, 2019--Techtonica happily announces that
+          <a
+            href="https://www.surveymonkey.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            >SurveyMonkey</a
+          >
+          has become a sponsor. SurveyMonkey will be joining a growing group of
+          Bay Area companies dedicated to Techtonica’s mission of empowering
+          local women and non-binary adults with low incomes through tech
+          training and job placement.
+        </p>
+        <p>
+          “It is fantastic to have SurveyMonkey become an advocate sponsor for
+          our participants,” said Techtonica Founder & CEO, Michelle Glauser.
+          “Our advocate sponsors provide the support needed for us to offer six
+          months of full-time training with living stipends and laptops to
+          participants, and at the end of the six months, sponsors have new
+          employees who can add their unique perspectives—as Bay Area women and
+          non-binary adults with low-income backgrounds—to the team.”
+        </p>
+        <p>
+          “We are focused on diversity and inclusion as a company and as an
+          engineering team, which means building a diverse workforce, and
+          creating an inclusive environment where every person feels comfortable
+          and empowered,” said Robin Ducot, SurveyMonkey CTO. “Techtonica’s
+          apprenticeship aligns perfectly with our values, and we are thrilled
+          to partner with them in helping underrepresented, underprivileged
+          individuals get the job skills and support they need to succeed in
+          software engineering.”
+        </p>
+        <p>
+          Techtonica’s six months of full-time training for its apprentices ends
+          in June and one lucky individual will start working at SurveyMonkey
+          thereafter.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Pantheon announces continued support for Techtonica
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Pantheon once again becomes a Techtonica advocate-level sponsor, this
+          time for the 2019 apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA Feb. 14, 2019--<a href="https://pantheon.io"
+            >Pantheon</a
+          >, Techtonica’s first-ever advocate-level hiring sponsor has returned
+          for the 2019 year to sponsor another class. Pantheon leads a growing
+          group of Bay Area companies dedicated to Techtonica’s mission of
+          empowering local women and non-binary adults with low incomes through
+          tech training and job placement.
+        </p>
+        <p>
+          “We are thrilled to have Pantheon on board again,” said Techtonica
+          Founder & CEO, Michelle Glauser. “They were early believers in our
+          mission to bridge the tech gap and we’re looking forward to seeing
+          what new opportunities we can create together. Our first graduate
+          placed with Pantheon has truly thrived, so there’s great potential in
+          our continued partnership.”
+        </p>
+        <p>
+          “The Bay Area often brags of innovation but it’s the Techtonica
+          program that delivers,” said Pantheon’s Service Engineer Tech Lead,
+          Michelle Krejci. “We plan to continue to grow our team of passionate,
+          creative, collaborative engineers with the graduates of Techtonica. We
+          are delighted to see so many tech companies that we admire lining up
+          now as well.”
+        </p>
+        <p>
+          Techtonica’s six months of full-time training for its apprentices ends
+          in June of this year and one lucky individual will start a three-month
+          job placement at Pantheon thereafter.
+        </p>
+        <p class="press-release-bold">About Pantheon</p>
+        <p>
+          Pantheon is a website operations platform for Drupal and WordPress,
+          running more than 200,000 sites in the cloud and serving over 10
+          billion pageviews a month. Pantheon's multitenant, container-based
+          platform enables web teams to manage all of their websites from a
+          single dashboard. Our secret sauce? Our passionate, creative,
+          collaborative team. Learn more at
+          <a href="https://pantheon.io">pantheon.io</a>.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Autonomic Partners with Techtonica to Help Women and Non-Binary Adults
+        Embark on Silicon Valley Careers
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Partnership supports an apprenticeship program where Techtonica
+          graduates intern with Autonomic’s engineering department and help
+          create the future of mobility.
+        </p>
+        <p>
+          SAN FRANCISCO, Calif. January 31, 2019 --- Autonomic, creators of the
+          Transportation Mobility Cloud (TMC), the first open, cloud-based
+          platform for connected vehicles, announce its sponsorship of
+          Techtonica’s apprenticeship program. Techtonica, a non-profit
+          organization focused on bridging Silicon Valley’s large gap in
+          workforce diversity, has created an apprenticeship program that
+          strives to bridge this gap by assisting women and non-binary adults
+          with low incomes to break into the high-tech workforce via
+          skill-building boot camps, job placement, and real-world mentorship.
+        </p>
+        <p>
+          Through its apprenticeship program, Techtonica takes aim at structural
+          and social obstacles to obtaining and succeeding in Silicon Valley
+          careers of women and non-binary adults of low-income with a six-month
+          bootcamp that extends into job placement and ongoing mentorship.
+          Techtonica apprentices are chosen from an applicant pool which
+          undergoes a rigorous application process that includes HTML/CSS
+          workshops, a JavaScript workshop, a code challenge, a long
+          application, pairing, and interviews by staff and board members.
+          Underscoring the demand for programs such as this, Techtonica accepts
+          approximately 8% of its applicants to each of its apprenticeship
+          cohorts. Successful applicants receive living stipends, laptops, and
+          more than 950 hours of full-time, project-based, collaborative
+          training on HTML, CSS, and JavaScript.
+        </p>
+        <p>
+          “It is absolutely essential that traditionally marginalized groups
+          have direct access to job-placement programs and mentorship if we want
+          to change things,” explained Techtonica Founder & CEO, Michelle
+          Glauser. “Autonomic clearly understands this and, since their
+          engineering team is working on some of the most interesting challenges
+          in transportation today, we’re thrilled to help them move mobility
+          forward with our graduates.”
+        </p>
+        <p>
+          This summer, a graduate from Techtonica’s apprenticeship program will
+          join Autonomic’s engineering team in Palo Alto and have the
+          opportunity to contribute directly to the TMC platform. The TMC
+          connects the disparate elements of the mobility ecosystem -- including
+          connected vehicles, mass transit, city infrastructure, and service
+          providers -- to orchestrate a safer, more efficient, and sustainable
+          transportation network. The brand-agnostic platform is the first to
+          unite the different parties involved in creating next-generation
+          transportation services with the goal of transforming how people move
+          around cities.
+        </p>
+        <p>
+          “Techtonica has created an effective and laudable program to help
+          those who are often overlooked in the workforce, and especially in the
+          tech industry,” remarked Gavin Sherry, CEO of Autonomic. “We are proud
+          to be able to support their efforts and are pleased to welcome their
+          graduates to Autonomic.”
+        </p>
+        <p>
+          The news follows an eventful 2018 for Autonomic. Beginning in February
+          2018, with their acquisition by Ford Smart Mobility, LLC, Autonomic
+          announced a series of partnerships across the transportation
+          ecosystem, including the provision of routing and mapping services for
+          any vehicle connected to the TMC via rideOS integration, and the
+          planned ability for fleet managers to connect their vehicles anywhere
+          in the world via low-cost satellites via Swarm Technologies. Autonomic
+          also expanded globally by partnering with Alibaba Cloud to bring TMC’s
+          benefits to the Chinese market.
+        </p>
+        <p class="press-release-bold">About Autonomic</p>
+        <p>
+          Autonomic is the first open cloud platform for connected vehicles,
+          powering the automotive digital ecosystem. As the only company to
+          create the world’s foremost transportation and mobility platform for
+          connected vehicles -- called the Transportation Mobility Cloud --
+          Autonomic gives car makers and developers the infrastructure to build
+          customer experiences for connected vehicles.
+        </p>
+        <p>
+          Founded in 2016, the Autonomic team hails from companies like Xtreme
+          Labs - acquired by Pivotal - and Amazon. Together, they architected
+          large-scale cloud computing platforms and built distribution databases
+          for well-known consumer mobile apps such as Tinder and Facebook. The
+          company is set to usher in a new era of connected vehicles and
+          transform how people move around cities. To learn more about
+          Autonomic, visit
+          <a
+            href="https://autonomic.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            >autonomic.ai</a
+          >.
+        </p>
+        <p class="press-release-bold">About Techtonica</p>
+        <p>
+          Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship
+          program based in San Francisco that partners with tech companies to
+          provide free, intensive tech training and job placement specifically
+          for Bay Area women and non-binary adults who have low incomes. Learn
+          more at techtonica.org.
+        </p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Agari announces support for Techtonica
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Agari becomes Techtonica’s newest advocate-level sponsor for the 2019
+          apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA Jan. 15th, 2019---Agari is happy to announce they
+          are becoming a sponsor of Bay Area nonprofit, Techtonica. Agari joins
+          a growing group of Bay Area companies dedicated to Techtonica’s
+          mission of empowering local women and non-binary adults with low
+          incomes through tech training and job placement.
+        </p>
+        <p>
+          “We are so excited to have Agari join us as an advocate sponsor for
+          our next cohort that will be starting in January,” said Techtonica
+          Founder & CEO, Michelle Glauser. “Agari’s work in cybersecurity and
+          email protection provides a unique opportunity for our future
+          apprentices.”
+        </p>
+        <p>
+          “We believe that optimizing our hiring process to find engineers who
+          enhance our community over solely looking for ‘rock star’ individuals
+          leads to a better outcome and a more diverse technology workforce,”
+          said Chris Haag, Senior Director of Engineering at Agari. “We're
+          supporting Techtonica's mission to provide training and support to
+          women and non-binary adults with low incomes and look forward to
+          supporting the 2019 cohort through their classes and internship.”
+        </p>
+        <p>
+          Techtonica’s six months of full-time technical training ends in June
+          2019, at which time a graduate of the program will begin working at
+          Agari.
+        </p>
+        <p class="press-release-bold">About Techtonica</p>
+        <p>
+          Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship
+          program based in San Francisco that partners with tech companies to
+          provide free, intensive tech training and job placement specifically
+          for Bay Area women and non-binary adults who have low incomes. Learn
+          more at
+          <a
+            href="https://techtonica.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >techtonica.org</a
+          >.
+        </p>
+        <p class="press-release-bold">About Agari</p>
+        <p>
+          Agari is the only cloud-native solution that uses predictive AI to
+          stop advanced email attacks. Winner of Best Email Security Solution by
+          SC Magazine in 2018, the Agari Email Trust Platform™ prevents
+          ransomware, ATO, phishing, BEC and other identity deception attacks,
+          restoring trust to digital channels for businesses, governments, and
+          consumers worldwide. Learn more at
+          <a
+            href="https://www.agari.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            >www.agari.com</a
+          >.
+        </p>
+        <p>
+          <a
+            href="https://www.agari.com"
+            target="_blank"
+            rel="noopener noreferrer"
+            ><img
+              src="{{ url_for('static', filename='img/agari-logo-min.png') }}"
+              alt="Agari logo"
+              class="resize-200px"
+          /></a>
+        </p>
+        <p>Media Contact:</p>
+        <p>Clinton Karr</p>
+        <p>
+          <a href="mailto:agari@summitstrategygroup.net"
+            >agari@summitstrategygroup.net</a
+          >
+        </p>
+        <p><a href="tel:415-993-1010">(415) 993-1010</a></p>
+      </div>
+    </li>
+    <li>
+      <button class="collapsible">
+        Kintone announces support for Techtonica
+      </button>
+      <div class="collapsible-content justify">
+        <p class="press-release-summary">
+          Kintone becomes Techtonica’s newest advocate-level sponsor for the
+          2019 apprenticeship.
+        </p>
+        <p>
+          SAN FRANCISCO, CA Dec. 17, 2018---Kintone proudly announces becoming a
+          sponsor of Bay Area nonprofit, Techtonica. Kintone will be joining a
+          growing group of Bay Area companies dedicated to Techtonica’s mission
+          of empowering local women and non-binary adults with low incomes
+          through tech training and job placement.
+        </p>
+        <p>
+          “We are thrilled to have Kintone join us as an advocate sponsor for
+          our next cohort that will be starting in January,” said Techtonica
+          Founder & CEO, Michelle Glauser.
+        </p>
+        <p>
+          “We’re thrilled to support Techtonica,” said Kintone CEO Dave Landa.
+          “As a cloud-based database platform company on a mission to make
+          teamwork better globally, this is an excellent opportunity to affirm
+          our commitment to diversity and inclusion of underserved communities
+          in the tech industry.”
+        </p>
+        <p>
+          Techtonica’s six months of full-time training for its apprentices ends
+          in June and one lucky individual will start working at Kintone
+          thereafter.
+        </p>
+        <p class="press-release-bold">About Techtonica</p>
+        <p>
+          Founded in 2016 by Michelle Glauser, Techtonica is an apprenticeship
+          program based in San Francisco that partners with tech companies to
+          provide free, intensive tech training and job placement specifically
+          for Bay Area women and non-binary adults who have low incomes. Learn
+          more at
+          <a
+            href="https://techtonica.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >techtonica.org</a
+          >.
+        </p>
+        <p class="press-release-bold">About Kintone</p>
+        <p>
+          San Francisco-based Kintone is making teamwork better with its no-code
+          application platform that provides organizations with a customizable
+          workspace that integrates multiple data sources for deeper insight
+          into business processes. Kintone eliminates the cost and maintenance
+          requirements of traditional off-the-shelf applications while
+          dramatically increasing team and workflow efficiency. More than 10,000
+          companies have built, deployed and use over 500,000 applications on
+          Kintone. Kintone is provided by Cybozu Inc, a Tokyo-based public
+          company founded in 1997. Both Kintone and Cybozu are designated as
+          great workplaces by Great Place to Work, a global authority on high
+          performing workplace cultures. For more information, please visit
+          <a
+            href="https://www.kintone.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >https://www.kintone.com/</a
+          >
+        </p>
+        <p>
+          <a
+            href="https://www.kintone.com/"
+            target="_blank"
+            rel="noopener noreferrer"
+            ><img
+              src="{{ url_for('static', filename='img/kintone-logo-min.png') }}"
+              alt="Kintone logo"
+              class="resize-200px"
+          /></a>
+        </p>
+      </div>
+    </li>
+  </ul>
 </div>
 <div class="column centered blue-background">
-	<h2 class="white-text">In other media</h2>
-	<ul class="hidden-bullets">
-		<li>
-			<p><a href="https://www.greaterthancode.com/adaptive-capacity-and-mutual-aid" target="_blank" rel="noopener noreferrer">Podcast: Adaptive Capacity and Mutual Aid with Michelle Glauser</a></p>
-			<p>Greater Than Code, June 2020</p>
-		</li>
-		<li>
-			<p><a href="https://www.bizjournals.com/sanfrancisco/news/2020/02/13/empowering-those-most-a-risk-with-free-technology.html" target="_blank" rel="noopener noreferrer">Empowering those most at-risk with free technology training</a></p>
-			<p>Business Times, February 2020</p>
-		</li>
-		<li>
-			<p><a href="https://elpha.com/posts/sh5y7e4d/bridging-the-tech-diversity-and-opportunity-gap-michelle-glauser-founder-of-techtonica" target="_blank" rel="noopener noreferrer">Bridging the tech diversity and opportunity gap</a></p>
-			<p>Elpha, December 2019</p>
-		</li>
-		<li>
-			<p><a href="https://www.forbes.com/sites/the74/2019/02/15/whats-keeping-girls-from-translating-soft-skills-superiority-into-stem-field-success/#23035051d67b" target="_blank" rel="noopener noreferrer">What's Keeping Girls From Translating 'Soft Skills' Superiority Into STEM Field Success?</a></p>
-			<p>Forbes, February 2019</p>
-		</li>
-		<li>
-			<p><a href="https://thebolditalic.com/diversity-in-tech-remains-embarrassingly-stagnant-these-nonprofits-could-help-1943b69cdb9b" target="_blank" rel="noopener noreferrer">Diversity in Tech Remains Embarrassingly Stagnant — These Groups Could Help</a></p>
-			<p>The Bold Italic, October 2018</p>
-		</li>
-		<li>
-			<p><a href="https://theartofsimple.net/podcast/146-2/" target="_blank" rel="noopener noreferrer">Podcast: A Diversity in Tech Champion</a></p>
-			<p>The Art of Simple, September 2018</p>
-		</li>
-		<li>
-			<p><a href="http://www.upworthy.com/how-do-we-get-more-diversity-in-tech-companies-easy-pay-for-it" target="_blank" rel="noopener noreferrer">How do we get more diversity in tech companies? Easy: Pay for it.</a></p>
-			<p>Upworthy, August 2017</p>
-		</li>
-		<li>
-			<p><a href="https://www.facebook.com/Upworthy/videos/1878354758872040/" target="_blank" rel="noopener noreferrer">Tech companies have a diversity problem. This woman raised her hand to help solve it.</a></p>
-			<p>Upworthy, July 2017</p>
-		</li>
-		<li>
-			<p><a href="http://www.yesmagazine.org/peace-justice/how-low-income-mothers-are-breaking-into-the-tech-industry-20170512" target="_blank" rel="noopener noreferrer">“How Low-Income Mothers Are Breaking Into the Tech Industry”</a></p>
-			<p>yes! Magazine, May 2017</p>
-		</li>
-	</ul>
-	<div class="row row__center blue-background">
-		<a href="https://www.dropbox.com/sh/e3x5gf8e4lc07u5/AAAIVwyfnD0PvxEt93XzBz1fa?dl=0" class="contact-us" id="orange-button" target="_blank" rel="noopener noreferrer">Logos for press</a>
-		{% include 'contactbutton.html' %}
-	</div>
+  <h2 class="white-text">In other media</h2>
+  <ul class="hidden-bullets">
+    <li>
+      <p>
+        <a
+          href="https://www.greaterthancode.com/adaptive-capacity-and-mutual-aid"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Podcast: Adaptive Capacity and Mutual Aid with Michelle Glauser</a
+        >
+      </p>
+      <p>Greater Than Code, June 2020</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://www.bizjournals.com/sanfrancisco/news/2020/02/13/empowering-those-most-a-risk-with-free-technology.html"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Empowering those most at-risk with free technology training</a
+        >
+      </p>
+      <p>Business Times, February 2020</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://elpha.com/posts/sh5y7e4d/bridging-the-tech-diversity-and-opportunity-gap-michelle-glauser-founder-of-techtonica"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Bridging the tech diversity and opportunity gap</a
+        >
+      </p>
+      <p>Elpha, December 2019</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://www.forbes.com/sites/the74/2019/02/15/whats-keeping-girls-from-translating-soft-skills-superiority-into-stem-field-success/#23035051d67b"
+          target="_blank"
+          rel="noopener noreferrer"
+          >What's Keeping Girls From Translating 'Soft Skills' Superiority Into
+          STEM Field Success?</a
+        >
+      </p>
+      <p>Forbes, February 2019</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://thebolditalic.com/diversity-in-tech-remains-embarrassingly-stagnant-these-nonprofits-could-help-1943b69cdb9b"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Diversity in Tech Remains Embarrassingly Stagnant — These Groups
+          Could Help</a
+        >
+      </p>
+      <p>The Bold Italic, October 2018</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://theartofsimple.net/podcast/146-2/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Podcast: A Diversity in Tech Champion</a
+        >
+      </p>
+      <p>The Art of Simple, September 2018</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="http://www.upworthy.com/how-do-we-get-more-diversity-in-tech-companies-easy-pay-for-it"
+          target="_blank"
+          rel="noopener noreferrer"
+          >How do we get more diversity in tech companies? Easy: Pay for it.</a
+        >
+      </p>
+      <p>Upworthy, August 2017</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="https://www.facebook.com/Upworthy/videos/1878354758872040/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Tech companies have a diversity problem. This woman raised her hand
+          to help solve it.</a
+        >
+      </p>
+      <p>Upworthy, July 2017</p>
+    </li>
+    <li>
+      <p>
+        <a
+          href="http://www.yesmagazine.org/peace-justice/how-low-income-mothers-are-breaking-into-the-tech-industry-20170512"
+          target="_blank"
+          rel="noopener noreferrer"
+          >“How Low-Income Mothers Are Breaking Into the Tech Industry”</a
+        >
+      </p>
+      <p>yes! Magazine, May 2017</p>
+    </li>
+  </ul>
+  <div class="row row__center blue-background">
+    <a
+      href="https://www.dropbox.com/sh/e3x5gf8e4lc07u5/AAAIVwyfnD0PvxEt93XzBz1fa?dl=0"
+      class="contact-us"
+      id="orange-button"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Logos for press</a
+    >
+    {% include 'contactbutton.html' %}
+  </div>
 </div>
 {% endblock content %}

--- a/templates/openings.html
+++ b/templates/openings.html
@@ -1,27 +1,32 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Careers
-{% endblock title %}
-
-{% block content %}
-  <div class="row row__center about-us">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
-           alt="A mentor works with a participant at a laptop." 
-           class="fixed-img" style="width:38%;">
-    </div>
-    <div class="column">
-      <h1 class="blue-h1">Openings</h1>
-      <p class="justify">Techtonica is a nonprofit that offers women and non-binary adults with low incomes free tech training, along with living and childcare stipends, then places them in positions at sponsoring companies that are ready to support more diverse teams. You can <a href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc">read more here</a>.</p>
-      <p>Make an Impact as Our:</p>
-      <p class="justify">
-        <h3>No openings at the moment; please check back later</h3>
-        <!-- <a href="{{ url_for('render_board_page') }}"><h3>Board Member</h3></a> -->
-      </p>
-      <div>
-        {% include 'contactbutton.html' %}
-      </div>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%;"
+    />
+  </div>
+  <div class="column">
+    <h1 class="blue-h1">Openings</h1>
+    <p class="justify">
+      Techtonica is a nonprofit that offers women and non-binary adults with low
+      incomes free tech training, along with living and childcare stipends, then
+      places them in positions at sponsoring companies that are ready to support
+      more diverse teams. You can
+      <a
+        href="https://medium.com/@michelleglauser/techtonica-how-to-diversify-tech-and-help-neighbors-in-need-837d5f0b40bc"
+        >read more here</a
+      >.
+    </p>
+    <p>Make an Impact as Our:</p>
+    <h3 class="justify">No openings at the moment; please check back later</h3>
+    <!-- <a href="{{ url_for('render_board_page') }}"><h3>Board Member</h3></a> -->
+    <div>
+      {% include 'contactbutton.html' %}
     </div>
   </div>
+</div>
 {% endblock content %}

--- a/templates/partnerdevmanager.html
+++ b/templates/partnerdevmanager.html
@@ -1,61 +1,105 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Careers
-{% endblock title %}
-
-{% block content %}
-  <div class="row row__center about-us">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
-           alt="A mentor works with a participant at a laptop." 
-           class="fixed-img" style="width:38%;">
-    </div>
-    <div class="column">
-      <h1 class="blue-h1">Openings</h1>
-      <p class="justify">Techtonica is a nonprofit that offers San Francisco Bay Area women and non-binary adults with low incomes free tech training, along with living and childcare stipends, then places them in positions at sponsoring companies that are ready to support more diverse teams.</p>
-
-      <h3>Make an Impact as Our Partnership Development Manager!</h3>
-
-      <p class="justify">Techtonica offers a life-changing learning experience to participants. We care deeply about helping our apprentices become high-quality software engineers.</p>
-
-      <p class="justify">We are seeking a committed individual to secure sponsors and manage those partnerships for Techtonica’s apprenticeship program so we can help more women and non-binary adults with low incomes learn tech skills and work in the tech industry. Unfortunately we are unable to offer visa sponsorship at this time.</p>
-
-      <p class="justify">The ideal candidate will be extremely passionate about the cause and the position and have the ability to quickly create and maintain positive and helpful partnerships. Techtonica is growing quickly, so we hope to find someone who can stick around and really grow the program with us.</p>
-
-      <p class="justify">Responsibilities:
-      <ul>
-        <li>Work out of our office in SoMa, San Francisco (this is a full-time position but we can be somewhat flexible on the hours)</li>
-        <li>Coordinate on strategy (the program’s selling points) and progress</li>
-        <li>Present Techtonica values and goals</li>
-        <li>Quickly and independently create, drive, and manage the sponsor pipeline through the sales cycle</li>
-        <li>Recruit new and existing partners to grow their involvement through donations, sponsoring, hosting, hiring, and other opportunities</li>
-        <li>Manage and track sponsor outreach and tasks in an organized, documented way</li>
-        <li>Represent Techtonica at events</li>
-      </ul>
-      </p>
-
-      <p class="justify">What we're looking for:
-        <ul>
-          <li>Proven experience in building strong relationships with other companies and organizations</li>
-          <li>Friendly and energetic personality</li>
-          <li>Great at negotiating, opportunity-spotting, being adaptable, and organizing</li>
-          <li>Familiarity with pipeline tools and managing multiple clients</li>
-          <li>Ability to juggle multiple tasks and manage multiple priorities at the same time without mixing them up</li>
-          <li>Proficiency in English and using LinkedIn, CRMs, and Google Suite tools</li>
-          <li>Contagious dedication to social justice</li>
-          <li>Ability to take focused responsibility for deliverables and deliver</li>
-        </ul>
-      </p>
-      <p class="justify">The Partnership Development Manager will get:
-        <ul>
-          <li>A MacBook to use for work</li>
-          <li>$28-$35 per hour (or $58,240-$72,800 per year), depending on experience</li>
-          <li>Benefits: sick leave, vacation, health insurance</li>
-          <li>A performance-based bonus</li>
-        </ul>
-      </p>
-      {% include 'contactbutton.html' %}
-    </div>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%;"
+    />
   </div>
+  <div class="column">
+    <h1 class="blue-h1">Openings</h1>
+    <p class="justify">
+      Techtonica is a nonprofit that offers San Francisco Bay Area women and
+      non-binary adults with low incomes free tech training, along with living
+      and childcare stipends, then places them in positions at sponsoring
+      companies that are ready to support more diverse teams.
+    </p>
+
+    <h3>Make an Impact as Our Partnership Development Manager!</h3>
+
+    <p class="justify">
+      Techtonica offers a life-changing learning experience to participants. We
+      care deeply about helping our apprentices become high-quality software
+      engineers.
+    </p>
+
+    <p class="justify">
+      We are seeking a committed individual to secure sponsors and manage those
+      partnerships for Techtonica’s apprenticeship program so we can help more
+      women and non-binary adults with low incomes learn tech skills and work in
+      the tech industry. Unfortunately we are unable to offer visa sponsorship
+      at this time.
+    </p>
+
+    <p class="justify">
+      The ideal candidate will be extremely passionate about the cause and the
+      position and have the ability to quickly create and maintain positive and
+      helpful partnerships. Techtonica is growing quickly, so we hope to find
+      someone who can stick around and really grow the program with us.
+    </p>
+
+    <p class="justify">Responsibilities:</p>
+    <ul>
+      <li>
+        Work out of our office in SoMa, San Francisco (this is a full-time
+        position but we can be somewhat flexible on the hours)
+      </li>
+      <li>
+        Coordinate on strategy (the program’s selling points) and progress
+      </li>
+      <li>Present Techtonica values and goals</li>
+      <li>
+        Quickly and independently create, drive, and manage the sponsor pipeline
+        through the sales cycle
+      </li>
+      <li>
+        Recruit new and existing partners to grow their involvement through
+        donations, sponsoring, hosting, hiring, and other opportunities
+      </li>
+      <li>
+        Manage and track sponsor outreach and tasks in an organized, documented
+        way
+      </li>
+      <li>Represent Techtonica at events</li>
+    </ul>
+
+    <p class="justify">What we're looking for:</p>
+    <ul>
+      <li>
+        Proven experience in building strong relationships with other companies
+        and organizations
+      </li>
+      <li>Friendly and energetic personality</li>
+      <li>
+        Great at negotiating, opportunity-spotting, being adaptable, and
+        organizing
+      </li>
+      <li>Familiarity with pipeline tools and managing multiple clients</li>
+      <li>
+        Ability to juggle multiple tasks and manage multiple priorities at the
+        same time without mixing them up
+      </li>
+      <li>
+        Proficiency in English and using LinkedIn, CRMs, and Google Suite tools
+      </li>
+      <li>Contagious dedication to social justice</li>
+      <li>
+        Ability to take focused responsibility for deliverables and deliver
+      </li>
+    </ul>
+    <p class="justify">The Partnership Development Manager will get:</p>
+    <ul>
+      <li>A MacBook to use for work</li>
+      <li>
+        $28-$35 per hour (or $58,240-$72,800 per year), depending on experience
+      </li>
+      <li>Benefits: sick leave, vacation, health insurance</li>
+      <li>A performance-based bonus</li>
+    </ul>
+    {% include 'contactbutton.html' %}
+  </div>
+</div>
 {% endblock content %}

--- a/templates/privacy.html
+++ b/templates/privacy.html
@@ -1,80 +1,150 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Privacy Policy
-{% endblock title %}
-
-{% block content %}
-  <div class="main-content">
-      <div class="main-header">
-        <div class="main-header__text blue-background">
-          <h1>Privacy Policy</h1>
-        </div>
-      </div>
-      <div class="row row__center long-form-conduct" id="longformconduct">
-        <div class="column">
-        <h3>Summary</h3>
-        <p>
-            This policy explains how we collect and treat any information you give us. You won’t find any complicated legal 
-            terms or long passages of unreadable text. We’ve no desire to trick you into agreeing to something you might 
-            later regret.
-        </p>
-            
-        <p class="justify">Our policy includes:</p>
-        <ul>
-            <li>Why we value your privacy</li>
-            <li>How we collect information</li>
-            <li>What information we hold</li>
-            <li>Where we store your information</li>
-            <li>What we use your information for</li>
-            <li>Who’s responsible for your information at our company</li>
-            <li>Who has access to information about you</li>
-            <li>The steps we take to keep your information private</li>
-            <li>How to complain</li>
-            <li>Changes to the policy</li>
-            <li>Why we value your privacy</li>       
-        </ul>
-        <p>We value your privacy as much as we do our own, so we’re committed to keeping your personal and business information safe. We ask for only the bare minimum from our users. We won’t use your personal information for any reason other than why you gave it, and we won’t give anyone access to it unless we’re forced to by law. </p>
-
-        <h3>How we collect information</h3>
-        <ul>
-            <li>We can ask for contact information including your name, email address, and phone number, on our website so that we can reply to your enquiry.</li>
-            <li>Our website doesn’t use cookies or scripts that were designed to track the websites you visit. We use Google Analytics and don’t use native social media ‘like’ or ‘sharing’ buttons which also build profiles of your internet activity.</li>
-            <li>We collect your email address when you sign up for one of our newsletters.</li>
-            <li>We ask for your account and contact information when you hire someone or buy something from us.</li>
-            <li>Occasionally, we might receive your contact information from one of our partners. If we do, we protect it in exactly the same way as if you give it to us directly.</li>
-        </ul>
-
-        <h3>What information we hold</h3>
-        <ul>
-            <li>When you contact us by email or through our website, we collect whichever information you’ve typed—usually your name, email address, phone number, a social media username, and the company you work for.</li>
-            <li>If you sign up for a newsletter, we only collect the information you entered into the form.</li>
-            <li>If you do business with us, we also collect your business name and bank details and keep records of the invoices we send you and the payments you make.</li>
-            <li>All credit card donations are processed by WeDidIt, our donation platform and we never have access to your credit card information.</li>
-        </ul>
-
-        <h3>Additional items</h3>
-        <ul>
-            <li>When you contact us by email or through our website, we store your information in HubSpot, Mailchimp, and Google Contacts. If you sign up for a newsletter, sign up as a volunteer, donate, or do business with us in some way, we store your email address in a private Google Spreadsheet and Eventbrite.</li>
-            <li>We occasionally use your contact information to send you details of our products and services. When we do, you have the option to unsubscribe from these communications and we won’t send them to you again. We might also contact you about our products and services, but if you tell us not to, we won’t get in touch again. We will use your information to send you invoices, statements, or reminders.</li>
-            <li>You can contact Techtonica by email at info at techtonica . org if you have any concerns about the information we store.</li>
-            <li>When we store information in our own systems, only the people who need it have access. Our admins have access to everything you’ve provided, but individuals have access to only what they need.</li>
-            <li>Where we store your information in third-party services, we restrict access only to people who need it. We store passwords in LastPass, an encrypted password manager, use a different, randomly generated password for each service, and do not use the same password twice.</li>
-        <li>The computers we use are all encrypted and protected by a passcode.</li>
-        </ul>
-
-        <p>How to complain</p>
-        <ul>
-        <li>We take complaints seriously. If you have any reason to complain about the ways we handle your privacy, please contact us by email at info at techtonica . org. If you’re the letter-writing type, send your envelope to Techtonica 340 S Lemon Ave. #5473, Walnut, CA 91789.
-        </li> 
-        </ul>
-
-
-    <p>If we change the contents of this policy, those changes will become effective the moment we publish them on our website.</p>  
-    <p>Source:
-    <a href="https://stuffandnonsense.co.uk/projects/protection-racket"> https://stuffandnonsense.co.uk/projects/protection-racket
-    </a>
-</p>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Privacy Policy {% endblock title %} {% block content %}
+<div class="main-content">
+  <div class="main-header">
+    <div class="main-header__text blue-background">
+      <h1>Privacy Policy</h1>
     </div>
   </div>
-{% endblock content %}
+  <div class="row row__center long-form-conduct" id="longformconduct">
+    <div class="column">
+      <h3>Summary</h3>
+      <p>
+        This policy explains how we collect and treat any information you give
+        us. You won’t find any complicated legal terms or long passages of
+        unreadable text. We’ve no desire to trick you into agreeing to something
+        you might later regret.
+      </p>
+
+      <p class="justify">Our policy includes:</p>
+      <ul>
+        <li>Why we value your privacy</li>
+        <li>How we collect information</li>
+        <li>What information we hold</li>
+        <li>Where we store your information</li>
+        <li>What we use your information for</li>
+        <li>Who’s responsible for your information at our company</li>
+        <li>Who has access to information about you</li>
+        <li>The steps we take to keep your information private</li>
+        <li>How to complain</li>
+        <li>Changes to the policy</li>
+        <li>Why we value your privacy</li>
+      </ul>
+      <p>
+        We value your privacy as much as we do our own, so we’re committed to
+        keeping your personal and business information safe. We ask for only the
+        bare minimum from our users. We won’t use your personal information for
+        any reason other than why you gave it, and we won’t give anyone access
+        to it unless we’re forced to by law.
+      </p>
+
+      <h3>How we collect information</h3>
+      <ul>
+        <li>
+          We can ask for contact information including your name, email address,
+          and phone number, on our website so that we can reply to your enquiry.
+        </li>
+        <li>
+          Our website doesn’t use cookies or scripts that were designed to track
+          the websites you visit. We use Google Analytics and don’t use native
+          social media ‘like’ or ‘sharing’ buttons which also build profiles of
+          your internet activity.
+        </li>
+        <li>
+          We collect your email address when you sign up for one of our
+          newsletters.
+        </li>
+        <li>
+          We ask for your account and contact information when you hire someone
+          or buy something from us.
+        </li>
+        <li>
+          Occasionally, we might receive your contact information from one of
+          our partners. If we do, we protect it in exactly the same way as if
+          you give it to us directly.
+        </li>
+      </ul>
+
+      <h3>What information we hold</h3>
+      <ul>
+        <li>
+          When you contact us by email or through our website, we collect
+          whichever information you’ve typed—usually your name, email address,
+          phone number, a social media username, and the company you work for.
+        </li>
+        <li>
+          If you sign up for a newsletter, we only collect the information you
+          entered into the form.
+        </li>
+        <li>
+          If you do business with us, we also collect your business name and
+          bank details and keep records of the invoices we send you and the
+          payments you make.
+        </li>
+        <li>
+          All credit card donations are processed by WeDidIt, our donation
+          platform and we never have access to your credit card information.
+        </li>
+      </ul>
+
+      <h3>Additional items</h3>
+      <ul>
+        <li>
+          When you contact us by email or through our website, we store your
+          information in HubSpot, Mailchimp, and Google Contacts. If you sign up
+          for a newsletter, sign up as a volunteer, donate, or do business with
+          us in some way, we store your email address in a private Google
+          Spreadsheet and Eventbrite.
+        </li>
+        <li>
+          We occasionally use your contact information to send you details of
+          our products and services. When we do, you have the option to
+          unsubscribe from these communications and we won’t send them to you
+          again. We might also contact you about our products and services, but
+          if you tell us not to, we won’t get in touch again. We will use your
+          information to send you invoices, statements, or reminders.
+        </li>
+        <li>
+          You can contact Techtonica by email at info at techtonica . org if you
+          have any concerns about the information we store.
+        </li>
+        <li>
+          When we store information in our own systems, only the people who need
+          it have access. Our admins have access to everything you’ve provided,
+          but individuals have access to only what they need.
+        </li>
+        <li>
+          Where we store your information in third-party services, we restrict
+          access only to people who need it. We store passwords in LastPass, an
+          encrypted password manager, use a different, randomly generated
+          password for each service, and do not use the same password twice.
+        </li>
+        <li>
+          The computers we use are all encrypted and protected by a passcode.
+        </li>
+      </ul>
+
+      <p>How to complain</p>
+      <ul>
+        <li>
+          We take complaints seriously. If you have any reason to complain about
+          the ways we handle your privacy, please contact us by email at info at
+          techtonica . org. If you’re the letter-writing type, send your
+          envelope to Techtonica 340 S Lemon Ave. #5473, Walnut, CA 91789.
+        </li>
+      </ul>
+
+      <p>
+        If we change the contents of this policy, those changes will become
+        effective the moment we publish them on our website.
+      </p>
+      <p>
+        Source:
+        <a href="https://stuffandnonsense.co.uk/projects/protection-racket">
+          https://stuffandnonsense.co.uk/projects/protection-racket
+        </a>
+      </p>
+    </div>
+  </div>
+  {% endblock content %}
+</div>

--- a/templates/seam.html
+++ b/templates/seam.html
@@ -1,70 +1,157 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — Careers
-{% endblock title %}
-
-{% block content %}
-  <div class="row row__center about-us">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
-           alt="A mentor works with a participant at a laptop." 
-           class="fixed-img" style="width:38%;">
-    </div>
-    <div class="column">
-      <h1 class="blue-h1">Openings</h1>
-      <p class="justify">Techtonica is a nonprofit (through fiscal sponsor Social Good Fund) that offers women and non-binary adults with low incomes free tech training, along with living and childcare stipends, then places them in positions at sponsoring companies.</p>
-      <h3>Make an Impact as Our Software Engineering Apprenticeship Manager</h3>
-
-      <p class="justify">Techtonica offers a life-changing learning experience to participants. We care deeply about helping the participants of our apprenticeship program become excellent software engineers with successful careers in tech.</p>
-
-      <p class="justify">We are looking for a committed, technical individual to start immediately as a Software Engineering Apprenticeship Manager (SEAM) for our six-month apprenticeship program in San Francisco (the next cohort will start in January). The SEAM will be responsible for preparing and implementing a training plan in line with current software standards. The SEAM will also provide technical guidance, knowledge, and leadership to participants while helping them develop their personal and professional skills.</p>
-
-      <p class="justify"><b><i>Our participants are Bay Area women and non-binary adults and most of them are people of color. We are seeking an individual who can relate to the target audience on as many levels as possible.</i></b></p>
-
-      <p class="justify">The ideal candidate will be passionate about the cause and the position and have the ability to create a relationship of mutual trust and leadership. They will know how to manage a group confidently and make learning an effective and meaningful process that truly prepares participants for the workplace.</p>
-
-      <p class="justify">This role's compensation will start between $80K and $130K annually (depending on experience), with the opportunity for review after six months. We can provide benefits, but we cannot provide visa sponsorship at this time.</p>
-
-      <p class="justify">Responsibilities:
-      <ul>
-        <li>Be present Monday-Friday 8:15am-5:15pm (with an hour-long lunch hour), and as needed for Techtonica events during the evenings and weekends</li>
-        <li>Manage participants of the apprenticeship program (with regular check-ins), volunteers, and mentors</li>
-        <li>Be the on-site software engineering expert—this means you'll present, explain, and answer questions about software engineering, pair, develop, and debug with participants</li>
-        <li>Conduct assessments and create efficient processes for assessments and more</li> 
-        <li>Continually improve training content (instruction, notes, summaries, assignments, schedules, etc.) that is up-to-date with software engineering best practices</li>
-        <li>Provide hands-on, project-based learning that builds portfolios for participants and fills sponsors' needs</li>
-        <li>Collaborate with the CEO on the program vision</li>
-        <li>Oversee the apprenticeship application process</li>
-        <li>Manage other program staff as assigned</li>
-      </ul>
-      </p>
-
-      <p class="justify">What we're looking for:
-        <ul>
-          <li>A minimum of two years of software engineering experience in the last four years</li>
-          <li>Excellence at teaching software engineering concepts</li>
-          <li>The ability to quickly familiarize yourself with Techtonica’s vision and all people involved (staff, participants, board members, volunteers, etc.)</li>
-          <li>Excellent communication and interpersonal skills</li>
-          <li>Strong moral values and discipline</li>
-          <li>Organization, commitment, and adaptability</li>
-          <li>Putting personal biases aside as needed</li>
-          <li>Understanding of socioeconomic experiences that our participants have faced</li>
-          <li>Being passionate and informed about social justice and diversity-and-inclusion-in-tech issues</li>
-          <li>An extrovert who is respectful of introverts’ needs</li>
-          <li>Ability to handle many different projects and tasks simultaneously and independently</li>
-          <li>Commitment to filling the role at Techtonica for at least an entire cohort, which is six months</li> 
-        </ul>
-      </p>
-
-      <p class="justify">
-        See <a href="https://github.com/Techtonica/curriculum/blob/master/README.md">some of the subjects we cover here</a>.
-      </p>
-      <p>The interview process involves an interview (online or in-person), contributing to the curriculum, pairing, and meeting board members. Please send your resume or a link to your LinkedIn profile and a link to your GitHub profile to info@techtonica.org if this role sounds like a good fit for you.</p>
-      {% include 'contactbutton.html' %}
-      <p></p></br>
-<!--       <p class="justify">Share this job via social media: <a href="https://twitter.com/TechtonicaOrg/status/1070239019223736320">Twitter</a>, <a href="https://www.facebook.com/Techtonica/photos/a.271768456523818/726457497721576/">Facebook</a>, <a href="https://www.linkedin.com/feed/update/urn:li:activity:6476004710842273792/">LinkedIn</a>, <a href="https://www.instagram.com/p/Bq_-Nw_gytq/">Instagram</a></p></br> -->
-    </div>
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%;"
+    />
   </div>
-<img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=1694756&conversionId=1681988&fmt=gif" />
+  <div class="column">
+    <h1 class="blue-h1">Openings</h1>
+    <p class="justify">
+      Techtonica is a nonprofit (through fiscal sponsor Social Good Fund) that
+      offers women and non-binary adults with low incomes free tech training,
+      along with living and childcare stipends, then places them in positions at
+      sponsoring companies.
+    </p>
+    <h3>Make an Impact as Our Software Engineering Apprenticeship Manager</h3>
+
+    <p class="justify">
+      Techtonica offers a life-changing learning experience to participants. We
+      care deeply about helping the participants of our apprenticeship program
+      become excellent software engineers with successful careers in tech.
+    </p>
+
+    <p class="justify">
+      We are looking for a committed, technical individual to start immediately
+      as a Software Engineering Apprenticeship Manager (SEAM) for our six-month
+      apprenticeship program in San Francisco (the next cohort will start in
+      January). The SEAM will be responsible for preparing and implementing a
+      training plan in line with current software standards. The SEAM will also
+      provide technical guidance, knowledge, and leadership to participants
+      while helping them develop their personal and professional skills.
+    </p>
+
+    <p class="justify">
+      <b
+        ><i
+          >Our participants are Bay Area women and non-binary adults and most of
+          them are people of color. We are seeking an individual who can relate
+          to the target audience on as many levels as possible.</i
+        ></b
+      >
+    </p>
+
+    <p class="justify">
+      The ideal candidate will be passionate about the cause and the position
+      and have the ability to create a relationship of mutual trust and
+      leadership. They will know how to manage a group confidently and make
+      learning an effective and meaningful process that truly prepares
+      participants for the workplace.
+    </p>
+
+    <p class="justify">
+      This role's compensation will start between $80K and $130K annually
+      (depending on experience), with the opportunity for review after six
+      months. We can provide benefits, but we cannot provide visa sponsorship at
+      this time.
+    </p>
+
+    <p class="justify">Responsibilities:</p>
+    <ul>
+      <li>
+        Be present Monday-Friday 8:15am-5:15pm (with an hour-long lunch hour),
+        and as needed for Techtonica events during the evenings and weekends
+      </li>
+      <li>
+        Manage participants of the apprenticeship program (with regular
+        check-ins), volunteers, and mentors
+      </li>
+      <li>
+        Be the on-site software engineering expert—this means you'll present,
+        explain, and answer questions about software engineering, pair, develop,
+        and debug with participants
+      </li>
+      <li>
+        Conduct assessments and create efficient processes for assessments and
+        more
+      </li>
+      <li>
+        Continually improve training content (instruction, notes, summaries,
+        assignments, schedules, etc.) that is up-to-date with software
+        engineering best practices
+      </li>
+      <li>
+        Provide hands-on, project-based learning that builds portfolios for
+        participants and fills sponsors' needs
+      </li>
+      <li>Collaborate with the CEO on the program vision</li>
+      <li>Oversee the apprenticeship application process</li>
+      <li>Manage other program staff as assigned</li>
+    </ul>
+
+    <p class="justify">What we're looking for:</p>
+    <ul>
+      <li>
+        A minimum of two years of software engineering experience in the last
+        four years
+      </li>
+      <li>Excellence at teaching software engineering concepts</li>
+      <li>
+        The ability to quickly familiarize yourself with Techtonica’s vision and
+        all people involved (staff, participants, board members, volunteers,
+        etc.)
+      </li>
+      <li>Excellent communication and interpersonal skills</li>
+      <li>Strong moral values and discipline</li>
+      <li>Organization, commitment, and adaptability</li>
+      <li>Putting personal biases aside as needed</li>
+      <li>
+        Understanding of socioeconomic experiences that our participants have
+        faced
+      </li>
+      <li>
+        Being passionate and informed about social justice and
+        diversity-and-inclusion-in-tech issues
+      </li>
+      <li>An extrovert who is respectful of introverts’ needs</li>
+      <li>
+        Ability to handle many different projects and tasks simultaneously and
+        independently
+      </li>
+      <li>
+        Commitment to filling the role at Techtonica for at least an entire
+        cohort, which is six months
+      </li>
+    </ul>
+
+    <p class="justify">
+      See
+      <a href="https://github.com/Techtonica/curriculum/blob/master/README.md"
+        >some of the subjects we cover here</a
+      >.
+    </p>
+    <p>
+      The interview process involves an interview (online or in-person),
+      contributing to the curriculum, pairing, and meeting board members. Please
+      send your resume or a link to your LinkedIn profile and a link to your
+      GitHub profile to info@techtonica.org if this role sounds like a good fit
+      for you.
+    </p>
+    {% include 'contactbutton.html' %}
+    <p></p>
+    <br />
+    <!--       <p class="justify">Share this job via social media: <a href="https://twitter.com/TechtonicaOrg/status/1070239019223736320">Twitter</a>, <a href="https://www.facebook.com/Techtonica/photos/a.271768456523818/726457497721576/">Facebook</a>, <a href="https://www.linkedin.com/feed/update/urn:li:activity:6476004710842273792/">LinkedIn</a>, <a href="https://www.instagram.com/p/Bq_-Nw_gytq/">Instagram</a></p></br> -->
+  </div>
+</div>
+<img
+  height="1"
+  width="1"
+  style="display: none;"
+  alt=""
+  src="https://px.ads.linkedin.com/collect/?pid=1694756&conversionId=1681988&fmt=gif"
+/>
 {% endblock content %}

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -1,222 +1,480 @@
-{% extends "base.html" %}
-
-{% block title %}
-	Techtonica: Bridging the Tech Gap
-{% endblock title %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block content %}
 <div class="main-content">
-    <div class="apprentice-header">
-    	<img id="apprentice-hero" src="{{ url_for('static', filename='img/apprentices-2019-long-cropped-min.jpg') }}">
+  <div class="apprentice-header">
+    <img
+      id="apprentice-hero"
+      src="{{ url_for('static', filename='img/apprentices-2019-long-cropped-min.jpg') }}"
+    />
+  </div>
+  <div class="row row__center blue-background" style="padding: 0;">
+    <h2 class="large-white-text">Sponsor today to help #BridgeTheTechGap!</h2>
+  </div>
+  <div class="row row__center">
+    <div class="column">
+      <p class="justify">
+        Techtonica offers six months of software engineering training with
+        monthly living and childcare stipends and laptops to local women and
+        non-binary adults with low incomes, then places graduates with sponsors.
+      </p>
+      <p class="justify">
+        By sponsoring, you're empowering the people most underrepresented in
+        tech and most in need. You’ll also save time and money on recruiting,
+        build diversity in tech, expand your network, gain new perspectives,
+        make better products, receive a tax exemption, join other distinguished
+        supporters, and lift the local community.
+      </p>
+      <p class="justify">
+        Make a positive social impact while filling your technical talent needs.
+      </p>
+      <h2>
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLSdNrE6qtdhND2eN3e4PbRfxa4ro1EKiQ3zYkKhYVxtbRXSsGg/viewform?usp=sf_link"
+          class="sponsor"
+          id="orange-button"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Discuss sponsoring</a
+        >
+      </h2>
+      <h2>
+        <a
+          href="https://www.dropbox.com/s/50gf4c3x4329lq9/Sponsoring%20and%20Hiring%20with%20Techtonica%20Info%20Sheet%202020.pdf?dl=0"
+          class="sponsor"
+          id="orange-button"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Download our sponsor info sheet</a
+        >
+      </h2>
+      <h2>
+        <a
+          href="https://www.youtube.com/watch?v=kgmLELNiWz4"
+          class="sponsor"
+          id="orange-button"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Watch our mid-cohort updates and sponsor info event from 3/25</a
+        >
+      </h2>
     </div>
-    <div class="row row__center blue-background" style="padding:0;">
-    	<h2 class="large-white-text">Sponsor today to help #BridgeTheTechGap!</h2>
+    <div class="column">
+      <a
+        href="https://www.dropbox.com/s/nvit8r1zrp3zx7v/Sponsoring%20and%20Hiring%20with%20Techtonica%20Info%20Sheet%202019.pdf?dl=0"
+      >
+        <img
+          src="{{ url_for('static', filename='img/sponsor-benefits.png') }}"
+          alt="Sponsor benefits chart"
+          class="full-width-img"
+        />
+      </a>
     </div>
-    <div class="row row__center">
-        <div class="column">
-          	<p class="justify">Techtonica offers six months of software engineering training with monthly living and childcare stipends and laptops to local women and non-binary adults with low incomes, then places graduates with sponsors.</p>
-			<p class="justify">By sponsoring, you're empowering the people most underrepresented in tech and most in need. You’ll also save time and money on recruiting, build diversity in tech, expand your network, gain new perspectives, make better products, receive a tax exemption, join other distinguished supporters, and lift the local community.</p>
-            <p class="justify">Make a positive social impact while filling your technical talent needs.</p>
-		    <h2><a href="https://docs.google.com/forms/d/e/1FAIpQLSdNrE6qtdhND2eN3e4PbRfxa4ro1EKiQ3zYkKhYVxtbRXSsGg/viewform?usp=sf_link" class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Discuss sponsoring</a></h2>
-	  	    <h2><a href="https://www.dropbox.com/s/50gf4c3x4329lq9/Sponsoring%20and%20Hiring%20with%20Techtonica%20Info%20Sheet%202020.pdf?dl=0" class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Download our sponsor info sheet</a></h2>
-	  	    <h2><a href="https://www.youtube.com/watch?v=kgmLELNiWz4" class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Watch our mid-cohort updates and sponsor info event from 3/25</a></h2>
-        </div>
-        <div class="column">
-          <a href="https://www.dropbox.com/s/nvit8r1zrp3zx7v/Sponsoring%20and%20Hiring%20with%20Techtonica%20Info%20Sheet%202019.pdf?dl=0">
-            <img src="{{ url_for('static', filename='img/sponsor-benefits.png') }}" alt="Sponsor benefits chart" class="full-width-img">
-          </a>
-    	</div>
+  </div>
+  <div class="row row__center blue-background">
+    <div class="column">
+      <a href="https://www.facebook.com/Techtonica/videos/631534610547199/">
+        <img
+          src="{{ url_for('static', filename='img/project-demo-min.jpg') }}"
+          alt="Participant holding a microphone and gesturing to a project demo"
+          class="full-width-img"
+        />
+      </a>
     </div>
-    <div class="row row__center blue-background">
-        <div class="column">
-			<a href="https://www.facebook.com/Techtonica/videos/631534610547199/">
-				<img src="{{ url_for('static', filename='img/project-demo-min.jpg') }}" alt="Participant holding a microphone and gesturing to a project demo" class="full-width-img">
-			</a>
-		</div>
-        <div class="column">
-          <p class="justify">We have a rigorous application process that includes HTML/CSS workshops, a JavaScript workshop, a code challenge, a long application, pairing, and interviews by staff as well as board members. Our acceptance rate is 8%. The characteristics we both seek in applicants and seek to strengthen in participants are resilience, autonomy, commitment, positivty & adaptability, collaboration, curiosity, and logic.</p>
-          <p class="justify">Developed by industry professionals, our six-month, sponsor-approved, open-source training covers full-stack JavaScript using hands-on projects. Participants build several projects, including a final project that is demoed during interviews and the graduation celebration—<a href="https://www.facebook.com/Techtonica/videos/631534610547199/" target="_blank" rel="noopener noreferrer">watch our 2018 project demos and placement announcements here.</a></p>
-          <p class="justify">Our participants spend the last weeks of training preparing to join the companies they've been matched with.</p>
-        </div>
+    <div class="column">
+      <p class="justify">
+        We have a rigorous application process that includes HTML/CSS workshops,
+        a JavaScript workshop, a code challenge, a long application, pairing,
+        and interviews by staff as well as board members. Our acceptance rate is
+        8%. The characteristics we both seek in applicants and seek to
+        strengthen in participants are resilience, autonomy, commitment,
+        positivty & adaptability, collaboration, curiosity, and logic.
+      </p>
+      <p class="justify">
+        Developed by industry professionals, our six-month, sponsor-approved,
+        open-source training covers full-stack JavaScript using hands-on
+        projects. Participants build several projects, including a final project
+        that is demoed during interviews and the graduation celebration—<a
+          href="https://www.facebook.com/Techtonica/videos/631534610547199/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >watch our 2018 project demos and placement announcements here.</a
+        >
+      </p>
+      <p class="justify">
+        Our participants spend the last weeks of training preparing to join the
+        companies they've been matched with.
+      </p>
     </div>
-    <div class="row row__center">
-		<div class="column centered">
-		    <a href="https://github.com/Techtonica/curriculum">
-		        <img src="{{ url_for('static', filename='img/topics-hours.png') }}" class="max-width-75-percent"/>
-		    </a>
-		</div>
-	</div>
-	<div class="row row__center blue-background">
-		<div class="column">
-			<p class="justify">Most of our participants are people of color, and we place 100% with hiring partners. All of our graduates still work in tech and most are still working with the companies we placed them with. <a href="https://medium.com/@techtonicaorg" target="_blank">Read more about our participants here</a>.</p>
-			<p class="justify">The best talent can’t be confined to gender, race, status, or age—let’s bring the best local talent to the best of tech.</p>
-		</div>
-		<div class="column centered">
-			<img src="{{ url_for('static', filename='img/2019-demographics.png') }}" class="max-width-75-percent" alt="Latinx: 36%, Black: 32%, East Asian: 14%, Southeast Asian: 9%, White: 9%"/>
-		</div>
-	</div>
-	<div class="row row__center">
-		<h1 class="blue-h1 centered">Join our hiring partners!</h1>
-		<div class="row">
-			<div class="column centered">
-				<a href="https://pantheon.io/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/pantheon-logo-min.jpg') }}"
-	                  alt="Pantheon.io logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://redfin.com" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/redfin-logo.png') }}"
-	                  alt="Redfin logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.ancestry.com" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/ancestry-logo-min.png') }}"
-	                  alt="Ancestry logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	              <a href="https://www.hugeinc.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/huge-logo-min.png') }}"
-	                  alt="Huge logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>    
-	            <a href="https://mixpanel.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/mixpanel-logo-min.png') }}"
-	                  alt="Mixpanel logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>   
-	            <a href="https://www.rallyhealth.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/rally-health-logo-min.png') }}"
-	                  alt="Rally Health logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.agari.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/agari-logo-min.png') }}"
-	                  alt="Agari logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.kintone.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/kintone-logo-min.png') }}"
-	                  alt="Kintone logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.autonomic.ai/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/Autonomic-logo-min.png') }}"
-	                  alt="Autonomic logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-              	<a href="https://www.quantcast.com" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/quantcast-logo-min.png') }}"
-	                  alt="Quantcast logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.surveymonkey.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/SurveyMonkey-logo-min.png') }}"
-	                  alt="SurveyMonkey logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.appdynamics.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/AppDynamics-logo-min.jpg') }}"
-	                  alt="AppDynamics logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.indeed.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/Indeed-logo-min.png') }}"
-	                  alt="Indeed logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-              	<a href="https://blend.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/Blend-logo.png') }}"
-	                  alt="Blend logo"
-	                  class="twenty-percent-width margin-25">
-              	</a>
-              	<a href="https://meraki.cisco.com/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/Cisco-Meraki-logo.jpg') }}"
-	                  alt="Cisco Meraki logo"
-	                  class="twenty-percent-width margin-25">
-              	</a>
-              	<a href="https://remix.com" target="_blank" rel="noopener noreferrer">
-                	<img src="{{ url_for('static', filename='img/Remix-logo-min.png') }}"
-                  	  alt="Remix logo"
-                  	  class="twenty-percent-width margin-25">
-              	</a>
-              	<a href="https://www.purestorage.com/" target="_blank" rel="noopener noreferrer">
-                	<img src="{{ url_for('static', filename='img/Pure-Storage-logo-min.png') }}"
-                  	  alt="Pure Storage logo"
-                  	  class="twenty-percent-width margin-25">
-              	</a>
-              	<a href="https://www.grove.co/" target="_blank" rel="noopener noreferrer">
-	                <img src="{{ url_for('static', filename='img/Grove-Collaborative-logo-min.png') }}"
-	                  alt="Grove Collaborative logo"
-	                  class="twenty-percent-width margin-25">
-	            </a>
-	            <a href="https://www.freenome.com/" target="_blank" rel="noopener noreferrer">
-                	<img src="{{ url_for('static', filename='img/Freenome-logo-min.png') }}"
-                      alt="Freenome logo"
-                      class="twenty-percent-width margin-25">
-              	</a>
-			</div>
-		</div>
-	</div>
-	<div class="row row__center blue-background">
-<!-- 		<h2 class="large-white-text">Become a sponsor today!</h2> -->
-<!-- 		<div class="progress-bg">
+  </div>
+  <div class="row row__center">
+    <div class="column centered">
+      <a href="https://github.com/Techtonica/curriculum">
+        <img
+          src="{{ url_for('static', filename='img/topics-hours.png') }}"
+          class="max-width-75-percent"
+        />
+      </a>
+    </div>
+  </div>
+  <div class="row row__center blue-background">
+    <div class="column">
+      <p class="justify">
+        Most of our participants are people of color, and we place 100% with
+        hiring partners. All of our graduates still work in tech and most are
+        still working with the companies we placed them with.
+        <a href="https://medium.com/@techtonicaorg" target="_blank"
+          >Read more about our participants here</a
+        >.
+      </p>
+      <p class="justify">
+        The best talent can’t be confined to gender, race, status, or age—let’s
+        bring the best local talent to the best of tech.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/2019-demographics.png') }}"
+        class="max-width-75-percent"
+        alt="Latinx: 36%, Black: 32%, East Asian: 14%, Southeast Asian: 9%, White: 9%"
+      />
+    </div>
+  </div>
+  <div class="row row__center">
+    <h1 class="blue-h1 centered">Join our hiring partners!</h1>
+    <div class="row">
+      <div class="column centered">
+        <a
+          href="https://pantheon.io/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/pantheon-logo-min.jpg') }}"
+            alt="Pantheon.io logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://redfin.com" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/redfin-logo.png') }}"
+            alt="Redfin logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.ancestry.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/ancestry-logo-min.png') }}"
+            alt="Ancestry logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.hugeinc.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/huge-logo-min.png') }}"
+            alt="Huge logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://mixpanel.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/mixpanel-logo-min.png') }}"
+            alt="Mixpanel logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.rallyhealth.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/rally-health-logo-min.png') }}"
+            alt="Rally Health logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.agari.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/agari-logo-min.png') }}"
+            alt="Agari logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.kintone.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/kintone-logo-min.png') }}"
+            alt="Kintone logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.autonomic.ai/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Autonomic-logo-min.png') }}"
+            alt="Autonomic logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.quantcast.com"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/quantcast-logo-min.png') }}"
+            alt="Quantcast logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.surveymonkey.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/SurveyMonkey-logo-min.png') }}"
+            alt="SurveyMonkey logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.appdynamics.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/AppDynamics-logo-min.jpg') }}"
+            alt="AppDynamics logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.indeed.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Indeed-logo-min.png') }}"
+            alt="Indeed logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://blend.com/" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Blend-logo.png') }}"
+            alt="Blend logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://meraki.cisco.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Cisco-Meraki-logo.jpg') }}"
+            alt="Cisco Meraki logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a href="https://remix.com" target="_blank" rel="noopener noreferrer">
+          <img
+            src="{{ url_for('static', filename='img/Remix-logo-min.png') }}"
+            alt="Remix logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.purestorage.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Pure-Storage-logo-min.png') }}"
+            alt="Pure Storage logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.grove.co/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Grove-Collaborative-logo-min.png') }}"
+            alt="Grove Collaborative logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+        <a
+          href="https://www.freenome.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <img
+            src="{{ url_for('static', filename='img/Freenome-logo-min.png') }}"
+            alt="Freenome logo"
+            class="twenty-percent-width margin-25"
+          />
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="row row__center blue-background">
+    <!-- 		<h2 class="large-white-text">Become a sponsor today!</h2> -->
+    <!-- 		<div class="progress-bg">
 	    	<div class="progress-bar">
 	        	<h3 class="raised large-white-text">50% of our goal</h3>
 	        </div>
 	        	<h3 class="goal"></h3>
 	    </div> -->
-	    <h2 class="large-white-text">Did you know 87% of Techtonica graduates are still with our sponsor companies? Here are some testimonials:</h2>
-			<p class="justify">“Everyone is super happy with the program and the quality of the apprentices. It was beyond what most were expecting.” —Jerome Despret, Director of Engineering at Pantheon</p>
-			<p class="justify">“Mentoring [our Techtonica grad] at Meraki has been incredibly rewarding, as I see her grow into a stronger and stronger engineer every week.” —Alexandra Savramis, Software Engineer at Cisco Meraki</p>
-			<p class="justify">“You could honestly match us with any one of them and it would be great.” —Jill Berardini, Software Engineer at Rally Health</p>
-			<p class="justify">“[Our Techtonica graduate] is beloved.” —Rachel Glickman, Director of Inclusion, Diversity, and Employee Relations at Rally Health</p>
-			<p class="justify">“We were very impressed by the level of foresight that went into the curriculum design.” —Michael Kyle, Director of Talent at Redbubble</p>
-	</div>
-	<div class="row row__center">
-		<div class="row row__center">
-			<h1 class="blue-h1 centered">How Hiring Works</h1>
-		</div>
-		<div class="row row__center">
-			<div class="column">
-				<h2>Sponsor</h2>
-				<p class="justify">Become a sponsor at the advocate level—this process includes signing an advocate sponsor agreement, receiving an invoice, paying the sponsorship fee, and announcing the partnership.</p>
-			</div>
-			<div class="column">
-				<img src="{{ url_for('static', filename='img/applicants-workshop.jpg') }}" alt="2018 cohort" class="full-width-img">
-			</div>
-		</div>
-		<div class="row row__center">
-			<div class="column">
-				<img src="{{ url_for('static', filename='img/apprentice-volunteers-2-min.jpg') }}" alt="2018 apprenticeship cohort" class="full-width-img">
-			</div>
-			<div class="column">
-				<h2>Get Involved and Strategize</h2>
-				<p class="justify">Get involved with Techtonica—you can volunteer, arrange a visit/video call, etc.</p>
-				<p class="justify">Determine your future employee’s position, team, duties, manager, and mentor. Possible positions include: software engineer, support engineer, technical program manager, sales engineer, QA engineer, and other "tech plus/adjacent" roles. See <a href="https://docs.google.com/document/d/1I0wWk9d1jPiZyqYwxC039BH3rHpXIPSeGOxSKmu-ucE/edit?usp=sharing" target="_blank">this doc for some of our past placement job descriptions</a>.</p>
-			</div>
-		</div>
-		<div class="row row__center">
-			<div class="column">
-				<h2>Find Your Match and Prepare</h2>
-				<p class="justify">Mutually rate and match with participants after they build their final projects.</p>
-				<p class="justify">Collaborate with your future employee on how to spend the last month preparing to join your team. Negotiate start date, pay (at least $30/hour), and other details.</p>
-			</div>
-			<div class="column">
-				<img src="{{ url_for('static', filename='img/apprentice-with-volunteer.jpg') }}" alt="2018 apprenticeship cohort" class="full-width-img">
-			</div>
-		</div>
-		<div class="row row__center">
-			<div class="column">
-				<img src="{{ url_for('static', filename='img/apprentice-volunteers-min.jpg') }}" alt="2018 apprenticeship cohort" class="full-width-img">
-			</div>
-			<div class="column">
-				<h2>Employ</h2>
-				<p class="justify">Enjoy having your matched graduate on your team for at least 1,000 hours!</p>
-			</div>
-		</div>
-		<div class="row row__center">
-			<h2><a href="https://docs.google.com/forms/d/e/1FAIpQLSdNrE6qtdhND2eN3e4PbRfxa4ro1EKiQ3zYkKhYVxtbRXSsGg/viewform?usp=sf_link" class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Contact us about sponsoring</a></h2>
-		</div>
-	</div>
-</div>		
+    <h2 class="large-white-text">
+      Did you know 87% of Techtonica graduates are still with our sponsor
+      companies? Here are some testimonials:
+    </h2>
+    <p class="justify">
+      “Everyone is super happy with the program and the quality of the
+      apprentices. It was beyond what most were expecting.” —Jerome Despret,
+      Director of Engineering at Pantheon
+    </p>
+    <p class="justify">
+      “Mentoring [our Techtonica grad] at Meraki has been incredibly rewarding,
+      as I see her grow into a stronger and stronger engineer every week.”
+      —Alexandra Savramis, Software Engineer at Cisco Meraki
+    </p>
+    <p class="justify">
+      “You could honestly match us with any one of them and it would be great.”
+      —Jill Berardini, Software Engineer at Rally Health
+    </p>
+    <p class="justify">
+      “[Our Techtonica graduate] is beloved.” —Rachel Glickman, Director of
+      Inclusion, Diversity, and Employee Relations at Rally Health
+    </p>
+    <p class="justify">
+      “We were very impressed by the level of foresight that went into the
+      curriculum design.” —Michael Kyle, Director of Talent at Redbubble
+    </p>
+  </div>
+  <div class="row row__center">
+    <div class="row row__center">
+      <h1 class="blue-h1 centered">How Hiring Works</h1>
+    </div>
+    <div class="row row__center">
+      <div class="column">
+        <h2>Sponsor</h2>
+        <p class="justify">
+          Become a sponsor at the advocate level—this process includes signing
+          an advocate sponsor agreement, receiving an invoice, paying the
+          sponsorship fee, and announcing the partnership.
+        </p>
+      </div>
+      <div class="column">
+        <img
+          src="{{ url_for('static', filename='img/applicants-workshop.jpg') }}"
+          alt="2018 cohort"
+          class="full-width-img"
+        />
+      </div>
+    </div>
+    <div class="row row__center">
+      <div class="column">
+        <img
+          src="{{ url_for('static', filename='img/apprentice-volunteers-2-min.jpg') }}"
+          alt="2018 apprenticeship cohort"
+          class="full-width-img"
+        />
+      </div>
+      <div class="column">
+        <h2>Get Involved and Strategize</h2>
+        <p class="justify">
+          Get involved with Techtonica—you can volunteer, arrange a visit/video
+          call, etc.
+        </p>
+        <p class="justify">
+          Determine your future employee’s position, team, duties, manager, and
+          mentor. Possible positions include: software engineer, support
+          engineer, technical program manager, sales engineer, QA engineer, and
+          other "tech plus/adjacent" roles. See
+          <a
+            href="https://docs.google.com/document/d/1I0wWk9d1jPiZyqYwxC039BH3rHpXIPSeGOxSKmu-ucE/edit?usp=sharing"
+            target="_blank"
+            >this doc for some of our past placement job descriptions</a
+          >.
+        </p>
+      </div>
+    </div>
+    <div class="row row__center">
+      <div class="column">
+        <h2>Find Your Match and Prepare</h2>
+        <p class="justify">
+          Mutually rate and match with participants after they build their final
+          projects.
+        </p>
+        <p class="justify">
+          Collaborate with your future employee on how to spend the last month
+          preparing to join your team. Negotiate start date, pay (at least
+          $30/hour), and other details.
+        </p>
+      </div>
+      <div class="column">
+        <img
+          src="{{ url_for('static', filename='img/apprentice-with-volunteer.jpg') }}"
+          alt="2018 apprenticeship cohort"
+          class="full-width-img"
+        />
+      </div>
+    </div>
+    <div class="row row__center">
+      <div class="column">
+        <img
+          src="{{ url_for('static', filename='img/apprentice-volunteers-min.jpg') }}"
+          alt="2018 apprenticeship cohort"
+          class="full-width-img"
+        />
+      </div>
+      <div class="column">
+        <h2>Employ</h2>
+        <p class="justify">
+          Enjoy having your matched graduate on your team for at least 1,000
+          hours!
+        </p>
+      </div>
+    </div>
+    <div class="row row__center">
+      <h2>
+        <a
+          href="https://docs.google.com/forms/d/e/1FAIpQLSdNrE6qtdhND2eN3e4PbRfxa4ro1EKiQ3zYkKhYVxtbRXSsGg/viewform?usp=sf_link"
+          class="sponsor"
+          id="orange-button"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Contact us about sponsoring</a
+        >
+      </h2>
+    </div>
+  </div>
+</div>
 {% endblock content %}

--- a/templates/team.html
+++ b/templates/team.html
@@ -1,166 +1,429 @@
-{% extends "base.html" %}
-
-{% block title %}
-  Techtonica: Bridging the Tech Gap — About Us
-{% endblock title %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+About Us {% endblock title %} {% block content %}
 
 <!--section for staff-->
+<div class="row row__center blue-background">
+  <div class="column centered">
+    <h1>Staff</h1>
+  </div>
   <div class="row row__center blue-background">
     <div class="column centered">
-      <h1>Staff</h1>
+      <img
+        src="{{ url_for('static', filename='img/Michelle-Glauser-min.jpg') }}"
+        alt="Michelle Glauser"
+        class="resize-400px"
+      />
     </div>
-    <div class="row row__center blue-background">
-      <div class = "column centered">
-        <img src="{{ url_for('static', filename='img/Michelle-Glauser-min.jpg') }}"
-             alt="Michelle Glauser"
-             class="resize-400px">
-      </div>
-      <div class="column centered">
-          <h2><a href="https://linkedin.com/in/michelleglauser" target="_blank" rel="noopener noreferrer">Michelle Glauser, Founder and CEO</a></h2>
-          <p class="justify">Since becoming a software engineer in 2012, she's worked for a better, more diverse software industry by organizing support groups, meetups, workshops, and the #ILookLikeAnEngineer ad campaign. Michelle's experience working in tech and volunteering in the community in San Francisco revealed two glaring issues: lack of diversity on tech teams and high income disparity. Techtonica is her vision to help tech companies and people who need more opportunities thrive together.</p>
-      </div>
-    </div>
-
-    <div class="row row__center blue-background">
-      <div class="column centered">
-          <h2><a href="https://www.linkedin.com/in/talea-carpenter/" target="_blank" rel="noopener noreferrer">TaLea Carpenter, <br>Associate Program Manager</a></h2>
-          <p class="justify">Before learning to code, TaLea spent the majority of her time
-homeschooling her children and making music. She has been recording music for over a decade and sees coding as another creative outlet. TaLea has organized both youth and parent/child coding workshops and co-organized a computer and wifi fundraiser for YoungBlood Coleman Park & Rec located in San Francisco, California. She worked at Ancestry following her training at Techtonica and is happy to be in a position to empower
-others.</p>
-      </div>
-      <div class = "column centered">
-        <img src="{{ url_for('static', filename='img/TaLea-min.jpg') }}"
-            alt="TaLea Carpenter"
-            class="resize-400px">
-      </div>
-    </div>
-
-    <div class="row row__center blue-background">
-      <div class = "column centered">
-        <img src="{{ url_for('static', filename='img/Tiffany-Quach-min.jpg') }}"
-            alt="Tiffany Quach"
-            class="resize-400px">
-      </div>
-      <div class="column centered">
-          <h2><a href="https://linkedin.com/in/tiffanyaquach/" target="_blank" rel="noopener noreferrer">Tiffany Quach, <br>Partnership Development Manager</a></h2>
-          <p class="justify">Tiffany has over 10 years of professional experience working in social impact. Prior to joining Techtonica, she managed a STEM and Environmental Education program for youth from communities that organizations have previously failed to engage. She is an experienced community builder and is impassioned about diversity, equity, and inclusion across all sectors. She is now excited to help create an inclusive tech ecosystem through partnership and relationship building.</p>
-        </div>
-    </div>
-    <div class="row row__center blue-background">
-      <div class="column centered">
-        <h2><a href="https://www.linkedin.com/in/bill-dephillips/" target="_blank" rel="noopener noreferrer">Bill DePhillips, Software Engineering Apprenticeship Manager</a></h2>
-        <p class="justify">
-          Bill has worked as a software engineer for over ten years in the Bay Area, most recently at <a href="https://www.goodreads.com">Goodreads</a>, an app to help you find your next favorite book. As an English major, he appreciates the need for pathways into tech that differ from the typical Computer Science route. A long-time volunteer and supporter of Techtonica, alongside other like-minded organizations, Bill is thrilled to be able to spend his efforts full-time on helping our participants learn the joy of coding as well as disrupting the industry from within by bringing long-missing voices to the table.
-        </p>
-      </div>
-      <div class = "column centered">
-        <img src="{{ url_for('static', filename='img/bill-dephillips-min.jpg') }}"
-             alt="Bill DePhillips"
-             class="resize-400px">
-      </div>
-    </div>
+    <div class="column centered">
+      <h2>
+        <a
+          href="https://linkedin.com/in/michelleglauser"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Michelle Glauser, Founder and CEO</a
+        >
+      </h2>
+      <p class="justify">
+        Since becoming a software engineer in 2012, she's worked for a better,
+        more diverse software industry by organizing support groups, meetups,
+        workshops, and the #ILookLikeAnEngineer ad campaign. Michelle's
+        experience working in tech and volunteering in the community in San
+        Francisco revealed two glaring issues: lack of diversity on tech teams
+        and high income disparity. Techtonica is her vision to help tech
+        companies and people who need more opportunities thrive together.
+      </p>
     </div>
   </div>
+
+  <div class="row row__center blue-background">
+    <div class="column centered">
+      <h2>
+        <a
+          href="https://www.linkedin.com/in/talea-carpenter/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >TaLea Carpenter, <br />Associate Program Manager</a
+        >
+      </h2>
+      <p class="justify">
+        Before learning to code, TaLea spent the majority of her time
+        homeschooling her children and making music. She has been recording
+        music for over a decade and sees coding as another creative outlet.
+        TaLea has organized both youth and parent/child coding workshops and
+        co-organized a computer and wifi fundraiser for YoungBlood Coleman Park
+        & Rec located in San Francisco, California. She worked at Ancestry
+        following her training at Techtonica and is happy to be in a position to
+        empower others.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/TaLea-min.jpg') }}"
+        alt="TaLea Carpenter"
+        class="resize-400px"
+      />
+    </div>
+  </div>
+
+  <div class="row row__center blue-background">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Tiffany-Quach-min.jpg') }}"
+        alt="Tiffany Quach"
+        class="resize-400px"
+      />
+    </div>
+    <div class="column centered">
+      <h2>
+        <a
+          href="https://linkedin.com/in/tiffanyaquach/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Tiffany Quach, <br />Partnership Development Manager</a
+        >
+      </h2>
+      <p class="justify">
+        Tiffany has over 10 years of professional experience working in social
+        impact. Prior to joining Techtonica, she managed a STEM and
+        Environmental Education program for youth from communities that
+        organizations have previously failed to engage. She is an experienced
+        community builder and is impassioned about diversity, equity, and
+        inclusion across all sectors. She is now excited to help create an
+        inclusive tech ecosystem through partnership and relationship building.
+      </p>
+    </div>
+  </div>
+  <div class="row row__center blue-background">
+    <div class="column centered">
+      <h2>
+        <a
+          href="https://www.linkedin.com/in/bill-dephillips/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Bill DePhillips, Software Engineering Apprenticeship Manager</a
+        >
+      </h2>
+      <p class="justify">
+        Bill has worked as a software engineer for over ten years in the Bay
+        Area, most recently at
+        <a href="https://www.goodreads.com">Goodreads</a>, an app to help you
+        find your next favorite book. As an English major, he appreciates the
+        need for pathways into tech that differ from the typical Computer
+        Science route. A long-time volunteer and supporter of Techtonica,
+        alongside other like-minded organizations, Bill is thrilled to be able
+        to spend his efforts full-time on helping our participants learn the joy
+        of coding as well as disrupting the industry from within by bringing
+        long-missing voices to the table.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/bill-dephillips-min.jpg') }}"
+        alt="Bill DePhillips"
+        class="resize-400px"
+      />
+    </div>
+  </div>
+</div>
 
 <!--section for board members-->
-  <div class="row row__center board-members" id="boardmembers">
-    <h1 class="blue-h1">Board Members</h1>
-    <div class="row">
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Alexandria-Spiva-min.jpg') }}"
-         alt="Alexandria Spiva"
-         class="resize-200px">
-       <footer><a href="https://www.linkedin.com/in/alexandria-spiva" target="_blank" rel="noopener noreferrer">Alexandria Spiva</a></footer>
-       <p>Alexandria has worked in tech for 13 years — at Yahoo, Facebook, LinkedIn, Airbnb, The Chan Zuckerberg Initiative, and currently Lyft. Alexandria has carried roles of Recruiter + D&I  thought leader to elevate programs and partnerships, along with re-designing approaches to hiring. Beyond her day-to-day, she does her knowledge-sharing through think tank sessions with various non-profits and panels such as Black Girls Code, Grace Hopper Conference, and Expat Women. She is passionate about diversity engagement and community building.</p>
-      </div>
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Kristina-Jobert-min.png') }}"
-          alt="Kristina Jobert"
-          class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/kristinajobert/" target="_blank" rel="noopener noreferrer">Kristina Jobert</a></footer>
-        <p>Kristina Jobert is a Director of Client Success and Solutions Architect at Verticurl, a global technology consulting firm, where she helps clients leverage their sales and marketing processes and tech stack. She has 8 years of experience in the software, SaaS, and cloud technology industry having worked for companies such as AdRoll and Neustar. She holds an undergraduate degree from the University of Arizona alongside her professional certifications from cloud companies like Salesforce and Marketo. Kristina is passionate about women in tech and strives to provide a gateway for women of color who aspire to learn code and advance in the tech field. In her spare time she enjoys spending time with her partner in crime, Stanley the Corgi.</p>
-      </div>
+<div class="row row__center board-members" id="boardmembers">
+  <h1 class="blue-h1">Board Members</h1>
+  <div class="row">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Alexandria-Spiva-min.jpg') }}"
+        alt="Alexandria Spiva"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/alexandria-spiva"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Alexandria Spiva</a
+        >
+      </footer>
+      <p>
+        Alexandria has worked in tech for 13 years — at Yahoo, Facebook,
+        LinkedIn, Airbnb, The Chan Zuckerberg Initiative, and currently Lyft.
+        Alexandria has carried roles of Recruiter + D&I thought leader to
+        elevate programs and partnerships, along with re-designing approaches to
+        hiring. Beyond her day-to-day, she does her knowledge-sharing through
+        think tank sessions with various non-profits and panels such as Black
+        Girls Code, Grace Hopper Conference, and Expat Women. She is passionate
+        about diversity engagement and community building.
+      </p>
     </div>
-
-    <div class="row">
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Krys-Flores-min.png') }}"
-          alt="Kry Flores"
-          class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/krystalflores/" target="_blank" rel="noopener noreferrer">Krys Flores</a></footer>
-        <p>Krys is a Senior Software Engineer at EarnUp, a fintech company that helps people pay bills on time and get out of debt faster. She is committed to increasing the number of female and Latinx computer programmers. Krys does this by giving technical talks and volunteering. In her talks, she seeks to give a face to those who are not usually represented amongst conference speakers. She believes the more you see, the more there will be. Krys is also a huge advocate of equal opportunities in the workforce, especially equal pay. In 2019 she was featured in the #NothingLess Micro Documentary by Hired. In 2018, she gave the talk “Applying Sheryl Sandberg’s Lean In principles in technology” as part of the Visionary Voices program.</p>
-      </div>
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Leah-Alpert-min.png') }}"
-          alt="Leah Alpert"
-          class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/leah-alpert-640b17b0" target="_blank" rel="noopener noreferrer">Leah Alpert</a></footer>
-        <p>Leah Alpert is a software engineering manager at Collective Health where she works on reinventing the way people interact with their health benefits. Leah is passionate about increasing the representation of women and underrepresented minorities in software engineering roles. After graduating from MIT with a degree in computer science, Leah spent the summer teaching computer science in Ghana before returning to San Francisco to work as a software engineer at Khan Academy. At Khan Academy, she built tools to help teachers and parents improve student outcomes. Now, at Collective Health, she leads engineering teams and runs the tech diversity team with the goal creating a more diverse and inclusive tech environment.</p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Melissa-Lucas-min.jpg') }}"
-         alt="Melissa Lucas"
-         class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/melissalucas/" target="_blank" rel="noopener noreferrer">Melissa Lucas</a></footer>
-        <p>
-            Melissa is editorial director for communications at CENIC, which operates a private internet network for most of California’s public research and education institutions, enabling researchers and students to discover and share new knowledge. She brings over 20 years of experience in nonprofit communications, marketing, publishing, outreach, and fundraising, and has worked in health care policy and civic technology for social services. After finishing her degree at UC Santa Cruz and working for reproductive rights in Costa Rica, only a strong, true mission gets her fired up. She’s thrilled to help spread the word about Techtonica.</p>
-      </div>
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Michelle-Grover-min.jpg') }}"
-          alt="Michelle Grover"
-          class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/michelle-grover-24b835149/" target="_blank" rel="noopener noreferrer">Michelle Grover</a></footer>
-        <p>Michelle started in technology in 1995 as a Systems Support Engineer by accident. She was originally in college for Physics and Structural Engineering but during the summer took on temporary work as the receptionist at AirTouch Paging (which became Verizon). At the end of her 90 days as a temp, Michelle was offered a permanent position as a Systems Support Engineer. She started with TripIt in October 2014 and was responsible for the Tripit R&D Team which includes the mobile, platform, and datamapper (itinerary parser) team and the Concur Mobile Teams in Bellevue, Prague, and Rot. Michelle has a teenaged son. In her spare time she volunteers at several organizations that focus on getting more women and girls interested in Software Development.</p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Suneet-Deol-min.jpg') }}"
-         alt="Suneet Deol"
-         class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/suneetdeol/" target="_blank" rel="noopener noreferrer">Suneet Deol</a></footer>
-        <p>Suneet Deol is a Senior Technical Program Manager at Box. Previously, she managed product ops and programs at SanDisk, a Western Digital brand, and worked as a Sales Engineer at Cal Sensors. At work, Suneet merges her technical and operations background to manage efficient and productive programs. Off the clock, she enjoys helping women find STEM careers, traveling, and healthy doses of Netflix and chocolate. Suneet holds a BS in Engineering from UC Davis and an MBA from USC’s Marshall School of Business.</p>
-      </div>
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/Zen-Mak-min.jpg') }}"
-         alt="Zen Mak"
-         class="resize-200px">
-	     <footer><a href="https://www.linkedin.com/in/zenmak/" target="_blank" rel="noopener noreferrer">Zen Mak</a></footer>
-	     <p>Zen Mak is the founder & CEO of Rallyworks. She previously led talent for high-growth and established companies including SquareTrade, Envoy, X - The Moonshot Factory (formerly known as Google X). Zen is a staunch advocate for best in class recruiting, people operations, diversity, inclusion & belonging initiatives and works tirelessly to help startups and companies navigate the talent landscape. In her spare time, you’ll find her working on her Landcruiser readying it for another Overlanding trip, solving Rubik’s cubes, or with her three dogs at parks in Oakland.</p>
-      </div>
-    </div>
-
-    <div class="row">
-      <div class="column centered">
-        <img src="{{ url_for('static', filename='img/nyghtowl.jpeg') }}"
-         alt="Melanie Warrick"
-         class="resize-200px">
-        <footer><a href="https://www.linkedin.com/in/melaniewarrick/" target="_blank" rel="noopener noreferrer">Melanie Warrick</a></footer>
-        <p>Melanie Warrick is at Google driving applied machine learning and Cloud advocacy. Previously, she implemented machine learning applications at Change.org as well as built a neural net software platform at a start-up. Before becoming a software engineer, she worked for over 10 years in business consulting at firms such as Accenture on projects for Fortune 500 companies and non-profits like CARE and Oxfam. Her global experience includes working in places like Kenya, Peru, England, Bangladesh, and Japan, and across many industries such as technology, retail, healthcare, media, non-profit, and energy. She holds an MBA and an undergraduate film degree from USC. Working with different organizations and independently, she has mentored and sponsored hundreds of people entering into technology and business fields.</p>
-      </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Kristina-Jobert-min.png') }}"
+        alt="Kristina Jobert"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/kristinajobert/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Kristina Jobert</a
+        >
+      </footer>
+      <p>
+        Kristina Jobert is a Director of Client Success and Solutions Architect
+        at Verticurl, a global technology consulting firm, where she helps
+        clients leverage their sales and marketing processes and tech stack. She
+        has 8 years of experience in the software, SaaS, and cloud technology
+        industry having worked for companies such as AdRoll and Neustar. She
+        holds an undergraduate degree from the University of Arizona alongside
+        her professional certifications from cloud companies like Salesforce and
+        Marketo. Kristina is passionate about women in tech and strives to
+        provide a gateway for women of color who aspire to learn code and
+        advance in the tech field. In her spare time she enjoys spending time
+        with her partner in crime, Stanley the Corgi.
+      </p>
     </div>
   </div>
+
+  <div class="row">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Krys-Flores-min.png') }}"
+        alt="Kry Flores"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/krystalflores/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Krys Flores</a
+        >
+      </footer>
+      <p>
+        Krys is a Senior Software Engineer at EarnUp, a fintech company that
+        helps people pay bills on time and get out of debt faster. She is
+        committed to increasing the number of female and Latinx computer
+        programmers. Krys does this by giving technical talks and volunteering.
+        In her talks, she seeks to give a face to those who are not usually
+        represented amongst conference speakers. She believes the more you see,
+        the more there will be. Krys is also a huge advocate of equal
+        opportunities in the workforce, especially equal pay. In 2019 she was
+        featured in the #NothingLess Micro Documentary by Hired. In 2018, she
+        gave the talk “Applying Sheryl Sandberg’s Lean In principles in
+        technology” as part of the Visionary Voices program.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Leah-Alpert-min.png') }}"
+        alt="Leah Alpert"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/leah-alpert-640b17b0"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Leah Alpert</a
+        >
+      </footer>
+      <p>
+        Leah Alpert is a software engineering manager at Collective Health where
+        she works on reinventing the way people interact with their health
+        benefits. Leah is passionate about increasing the representation of
+        women and underrepresented minorities in software engineering roles.
+        After graduating from MIT with a degree in computer science, Leah spent
+        the summer teaching computer science in Ghana before returning to San
+        Francisco to work as a software engineer at Khan Academy. At Khan
+        Academy, she built tools to help teachers and parents improve student
+        outcomes. Now, at Collective Health, she leads engineering teams and
+        runs the tech diversity team with the goal creating a more diverse and
+        inclusive tech environment.
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Melissa-Lucas-min.jpg') }}"
+        alt="Melissa Lucas"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/melissalucas/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Melissa Lucas</a
+        >
+      </footer>
+      <p>
+        Melissa is editorial director for communications at CENIC, which
+        operates a private internet network for most of California’s public
+        research and education institutions, enabling researchers and students
+        to discover and share new knowledge. She brings over 20 years of
+        experience in nonprofit communications, marketing, publishing, outreach,
+        and fundraising, and has worked in health care policy and civic
+        technology for social services. After finishing her degree at UC Santa
+        Cruz and working for reproductive rights in Costa Rica, only a strong,
+        true mission gets her fired up. She’s thrilled to help spread the word
+        about Techtonica.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Michelle-Grover-min.jpg') }}"
+        alt="Michelle Grover"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/michelle-grover-24b835149/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Michelle Grover</a
+        >
+      </footer>
+      <p>
+        Michelle started in technology in 1995 as a Systems Support Engineer by
+        accident. She was originally in college for Physics and Structural
+        Engineering but during the summer took on temporary work as the
+        receptionist at AirTouch Paging (which became Verizon). At the end of
+        her 90 days as a temp, Michelle was offered a permanent position as a
+        Systems Support Engineer. She started with TripIt in October 2014 and
+        was responsible for the Tripit R&D Team which includes the mobile,
+        platform, and datamapper (itinerary parser) team and the Concur Mobile
+        Teams in Bellevue, Prague, and Rot. Michelle has a teenaged son. In her
+        spare time she volunteers at several organizations that focus on getting
+        more women and girls interested in Software Development.
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Suneet-Deol-min.jpg') }}"
+        alt="Suneet Deol"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/suneetdeol/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Suneet Deol</a
+        >
+      </footer>
+      <p>
+        Suneet Deol is a Senior Technical Program Manager at Box. Previously,
+        she managed product ops and programs at SanDisk, a Western Digital
+        brand, and worked as a Sales Engineer at Cal Sensors. At work, Suneet
+        merges her technical and operations background to manage efficient and
+        productive programs. Off the clock, she enjoys helping women find STEM
+        careers, traveling, and healthy doses of Netflix and chocolate. Suneet
+        holds a BS in Engineering from UC Davis and an MBA from USC’s Marshall
+        School of Business.
+      </p>
+    </div>
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/Zen-Mak-min.jpg') }}"
+        alt="Zen Mak"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/zenmak/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Zen Mak</a
+        >
+      </footer>
+      <p>
+        Zen Mak is the founder & CEO of Rallyworks. She previously led talent
+        for high-growth and established companies including SquareTrade, Envoy,
+        X - The Moonshot Factory (formerly known as Google X). Zen is a staunch
+        advocate for best in class recruiting, people operations, diversity,
+        inclusion & belonging initiatives and works tirelessly to help startups
+        and companies navigate the talent landscape. In her spare time, you’ll
+        find her working on her Landcruiser readying it for another Overlanding
+        trip, solving Rubik’s cubes, or with her three dogs at parks in Oakland.
+      </p>
+    </div>
+  </div>
+
+  <div class="row">
+    <div class="column centered">
+      <img
+        src="{{ url_for('static', filename='img/nyghtowl.jpeg') }}"
+        alt="Melanie Warrick"
+        class="resize-200px"
+      />
+      <footer>
+        <a
+          href="https://www.linkedin.com/in/melaniewarrick/"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Melanie Warrick</a
+        >
+      </footer>
+      <p>
+        Melanie Warrick is at Google driving applied machine learning and Cloud
+        advocacy. Previously, she implemented machine learning applications at
+        Change.org as well as built a neural net software platform at a
+        start-up. Before becoming a software engineer, she worked for over 10
+        years in business consulting at firms such as Accenture on projects for
+        Fortune 500 companies and non-profits like CARE and Oxfam. Her global
+        experience includes working in places like Kenya, Peru, England,
+        Bangladesh, and Japan, and across many industries such as technology,
+        retail, healthcare, media, non-profit, and energy. She holds an MBA and
+        an undergraduate film degree from USC. Working with different
+        organizations and independently, she has mentored and sponsored hundreds
+        of people entering into technology and business fields.
+      </p>
+    </div>
+  </div>
+</div>
 
 <!--section for original picture and paragraph-->
-  <div class="row row__center techtonica-squad" id="techtonicasquad">
-    <div class="column hidden-med">
-      <img src="{{ url_for('static', filename='img/april-workshop-group-min.jpg') }}"
-           alt="Fifteen participants, mostly women, gathered after a workshop."
-           class="full-width-img">
-    </div>
-    <div class="column">
-      <p class="justify">The Techtonica Squad includes software engineers, community volunteers and leaders, non-profit and startup founders, teachers, curriculum development specialists, venture capitalists, and social impact strategists.</p>
-      <p class="justify">Apply for <a href="{{ url_for('render_openings_page') }}">open roles</a> or to be <a href="http://bit.ly/volunteer-with-Techtonica" class="hover-link" target="_blank" rel="noopener noreferrer">a volunteer</a> or <a href="{{ url_for('render_mentor_page') }}">mentor</a>.</p>
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link" class="contact-us" id="orange-button" target="_blank" rel="noopener noreferrer">Contact us</a>
-    </div>
-    </div>
-
+<div class="row row__center techtonica-squad" id="techtonicasquad">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/april-workshop-group-min.jpg') }}"
+      alt="Fifteen participants, mostly women, gathered after a workshop."
+      class="full-width-img"
+    />
   </div>
+  <div class="column">
+    <p class="justify">
+      The Techtonica Squad includes software engineers, community volunteers and
+      leaders, non-profit and startup founders, teachers, curriculum development
+      specialists, venture capitalists, and social impact strategists.
+    </p>
+    <p class="justify">
+      Apply for
+      <a href="{{ url_for('render_openings_page') }}">open roles</a> or to be
+      <a
+        href="http://bit.ly/volunteer-with-Techtonica"
+        class="hover-link"
+        target="_blank"
+        rel="noopener noreferrer"
+        >a volunteer</a
+      >
+      or <a href="{{ url_for('render_mentor_page') }}">mentor</a>.
+    </p>
+    <a
+      href="https://docs.google.com/forms/d/e/1FAIpQLScjCF6_xzIn-Uht3MDOr1__3YpIYDCTzx80cIE0KVCsPqcYKQ/viewform?usp=sf_link"
+      class="contact-us"
+      id="orange-button"
+      target="_blank"
+      rel="noopener noreferrer"
+      >Contact us</a
+    >
+  </div>
+</div>
 
 {% endblock content %}

--- a/templates/thankyou.html
+++ b/templates/thankyou.html
@@ -1,21 +1,26 @@
-{% extends "base.html" %}
-
-{% block title %}
-	Techtonica: Bridging the Tech Gap
-{% endblock title %}
-
-{% block popup %}{% endblock %}
-
-{% block content %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block popup %}{% endblock %} {% block content %}
 
 <div class="row row__center">
-	<div class="column">
-    	<h1 class="blue-h1">Thank you!</h1>
-    	<h3>We will be in touch!</h3>
-    	<p>In the meantime, you can check out <a href="{{ url_for('render_home_page') }}">our home page</a> or look through <a href="{{ url_for('render_faqs_page') }}">our frequently-asked questions (FAQs)</a>. 
-    </div>
-    <div class="column">
-    	<img src="{{ url_for('static', filename='img/bridge-the-tech-gap-participant.png') }}" alt="Participant at computer, image has 'Bridge the tech gap' on it." class="full-width-img">
+  <div class="column">
+    <h1 class="blue-h1">Thank you!</h1>
+    <h3>We will be in touch!</h3>
+    <p>
+      In the meantime, you can check out
+      <a href="{{ url_for('render_home_page') }}">our home page</a> or look
+      through
+      <a href="{{ url_for('render_faqs_page') }}"
+        >our frequently-asked questions (FAQs)</a
+      >.
+    </p>
+  </div>
+
+  <div class="column">
+    <img
+      src="{{ url_for('static', filename='img/bridge-the-tech-gap-participant.png') }}"
+      alt="Participant at computer, image has 'Bridge the tech gap' on it."
+      class="full-width-img"
+    />
   </div>
 </div>
 

--- a/templates/volunteer.html
+++ b/templates/volunteer.html
@@ -1,48 +1,104 @@
-{% extends "base.html" %}
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap {%
+endblock title %} {% block content %}
 
-{% block title %}
-  Techtonica: Bridging the Tech Gap
-{% endblock title %}
-
-{% block content %}
-
-  <div class="row row__center blue-background">
-    <div class="column">
-      <h1>How to Help</h1>
-      <p class="justify">
-        <ul>
-          <li><a href="{{ url_for('render_donate_page') }}" class="hover-link" target="_blank" rel="noopener noreferrer">Donate</a> (donations are tax-deductible, $5000 will get your face on our home page, and you can sign up to donate monthly).</li>
-          <li>Encourage your company to <a href="{{ url_for('render_sponsor_page') }}">sponsor and hire apprentices</a>.</li>
-          <li><a href="http://bit.ly/volunteer-with-Techtonica" class="hover-link" target="_blank" rel="noopener noreferrer">Sign up to volunteer</a>.</li>
-        </ul>
-     </p>
-      <p class="justify">To receive updates, please <a id="open-popup" class="hover-link newsletter pad-lv3 pad-tb0" href="http://eepurl.com/cNFqmj" target="_blank" rel="noopener noreferrer">sign up for our newsletter</a>.</p>
-    </div>
-    <div class="column">
-      <img src="{{ url_for('static', filename='img/listening-volunteers-min.png') }}" alt="Volunteers listening to woman speaking" class="full-width-img">
-    </div>
+<div class="row row__center blue-background">
+  <div class="column">
+    <h1>How to Help</h1>
+    <ul>
+      <li>
+        <a
+          href="{{ url_for('render_donate_page') }}"
+          class="hover-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Donate</a
+        >
+        (donations are tax-deductible, $5000 will get your face on our home
+        page, and you can sign up to donate monthly).
+      </li>
+      <li>
+        Encourage your company to
+        <a href="{{ url_for('render_sponsor_page') }}"
+          >sponsor and hire apprentices</a
+        >.
+      </li>
+      <li>
+        <a
+          href="http://bit.ly/volunteer-with-Techtonica"
+          class="hover-link"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Sign up to volunteer</a
+        >.
+      </li>
+    </ul>
+    <p class="justify">
+      To receive updates, please
+      <a
+        id="open-popup"
+        class="hover-link newsletter pad-lv3 pad-tb0"
+        href="http://eepurl.com/cNFqmj"
+        target="_blank"
+        rel="noopener noreferrer"
+        >sign up for our newsletter</a
+      >.
+    </p>
   </div>
+  <div class="column">
+    <img
+      src="{{ url_for('static', filename='img/listening-volunteers-min.png') }}"
+      alt="Volunteers listening to woman speaking"
+      class="full-width-img"
+    />
+  </div>
+</div>
 
-  <div class="row">
-    <div class="column centered">
-      <ul>
-        <h2>Visit us</h2>
-        <li><a href="https://www.eventbrite.com/o/techtonica-11297022451" target="_blank" rel="noopener noreferrer">
+<div class="row">
+  <div class="column centered">
+    <ul>
+      <h2>Visit us</h2>
+      <li>
+        <a
+          href="https://www.eventbrite.com/o/techtonica-11297022451"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Our events on Eventbrite
-        </a></li>
-        <li><a href="https://teamup.com/ksnie3b3q5frepnd92" target="_blank" rel="noopener noreferrer">
+        </a>
+      </li>
+      <li>
+        <a
+          href="https://teamup.com/ksnie3b3q5frepnd92"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           Schedule a visit on our calendar
-        </a></li>
-      </ul>
-    </div>
-
-    <div class="column centered">
-      <ul>
-        <h2>Open-source projects</h2>
-        <li><a href="https://github.com/Techtonica/curriculum/issues" target="_blank" rel="noopener noreferrer">Contribute to our curriculum</a></li>
-        <li><a href="https://github.com/MichelleGlauser/techtonica/issues" target="_blank" rel="noopener noreferrer">Contribute to our website</a></li>
-      </ul>
-    </div>
+        </a>
+      </li>
+    </ul>
   </div>
+
+  <div class="column centered">
+    <ul>
+      <h2>Open-source projects</h2>
+      <li>
+        <a
+          href="https://github.com/Techtonica/curriculum/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Contribute to our curriculum</a
+        >
+      </li>
+      <li>
+        <a
+          href="https://github.com/MichelleGlauser/techtonica/issues"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Contribute to our website</a
+        >
+      </li>
+    </ul>
+  </div>
+</div>
 
 {% endblock content %}


### PR DESCRIPTION
Use the Python [pre-commit](https://pre-commit.com) tool to install hooks that enforce coding and formatting standards. The following hooks are enforced:

* flake8 for Python style and syntax
* isort for Python import statement sorting
* black for Python code formatting
* prettier for everything else formatting

`.editorconfig` is also added for editors that pick up formatting guidelines for this project.

Included in this PR are changes to existing files in order to pass the enforced standards (mostly fix invalid markup).

/cc @MichelleGlauser @vegetabill 

Address #175 