### PR TITLE
Address case where an event has no venue

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -90,12 +90,14 @@ def render_openings_page():
     """
     return render_template("openings.html")
 
+
 """
 @app.route("/openings/seam/")
 def render_seam_page():
     Renders the openings page from jinja2 template
     return render_template("seam.html")
 """
+
 
 @app.route("/openings/curriculumdev/")
 def render_curriculumdev_page():
@@ -168,13 +170,19 @@ class Event(object):
     def __init__(self, event):
         self.title = event["name"]["text"]
         self.url = event["url"]
-        self.venue = event["venue"]["name"]
-        self.address = event["venue"]["address"]["localized_multi_line_address_display"]
+        self.venue = None
+        self.address = None
         self.date = (
             pendulum.parse(event["start"]["local"])
             .set(tz=event["start"]["timezone"])
             .format("MMMM D, YYYY, h:mmA zz")
         )
+
+        if event["venue"]:
+            self.venue = event["venue"]["name"]
+            self.address = event["venue"]["address"][
+                "localized_multi_line_address_display"
+            ]
 
 
 if __name__ == "__main__":

--- a/templates/home.html
+++ b/templates/home.html
@@ -67,11 +67,13 @@
             <div class="column centered blue-background event-item" id="eventbrite">
               <h3 class="blue-background"><a href="{{event.url}}">{{event.title}}</a></h3>
               <p class="event-item__address blue-background">{{event.date}}</p>
+              {% if event.venue %}
               <p class="event-item__address blue-background">{{event.venue}}
                 {% for a in event.address %}
                   <br>{{a}}
                 {% endfor %}
               </p>
+              {% endif %}
             </div>
           {% endfor %}
         </div>


### PR DESCRIPTION
The site was crashing because each event was expected to have a venue associated with it. However, there are events with `venue = None`.

* Only initialize venue related data when there's a venue present in an event
* Don't try to render venue related data in the template if there's no venue