### PR TITLE
add app closing date to apply button and clarify free vs tuition across site

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Important: Only ever Pull form the server!
   systemctl --user restart gunicorn_staging 
   systemctl --user status gunicorn_staging
 
-	       // testing.techtonica.org
+  // testing.techtonica.org
   systemctl --user stop gunicorn_testing
   systemctl --user restart gunicorn_testing
   systemctl --user status gunicorn_testing

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Important: Only ever Pull form the server!
   systemctl --user status gunicorn_testing
 
   // techtonica.org
-  systemctl --user enable gunicorn_techtonica
+  systemctl --user stop gunicorn_techtonica
   systemctl --user enable gunicorn_techtonica
   systemctl --user restart gunicorn_techtonica
   systemctl --user status gunicorn_techtonica

--- a/README.md
+++ b/README.md
@@ -249,16 +249,19 @@ Important: Only ever Pull form the server!
   ```sh
 
   // staging.techtonica.org
-  systemctl --user s stop unicorn_staging
+  systemctl --user stop gunicorn_staging
+  systemctl --user enable gunicorn_staging
   systemctl --user restart gunicorn_staging 
   systemctl --user status gunicorn_staging
 
-  // testing.techtonica.org
+	// testing.techtonica.org
   systemctl --user stop gunicorn_testing
+  systemctl --user enable gunicorn_testing
   systemctl --user restart gunicorn_testing
   systemctl --user status gunicorn_testing
 
   // techtonica.org
+  systemctl --user enable gunicorn_techtonica
   systemctl --user enable gunicorn_techtonica
   systemctl --user restart gunicorn_techtonica
   systemctl --user status gunicorn_techtonica

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,20 +12,21 @@
     </title>
     <meta
       name="description"
-      content="We partner with tech companies to offer tech training, laptops, living and childcare stipends, and job placement to women and 
+      content="We partner with tech companies to offer tech training, laptops, living and childcare stipend scholarships, and job placement to women and 
       non-binary adults with low incomes."
     />
     <meta
       name="keywords"
-      content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, low income, free tech training, coding, 
-      women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer adults, #BridgeTheTechGap, adult education, 
-      vocational training, workforce development, tech jobs, San Francisco, sf, Silicon Valley, Bay Area, remote learning, virtual, join tech,
-      software engineering, learn to code, tech education, software developer school, web development, Michelle Glauser, become a software engineer"
+      content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, need-based, sliding-scale, subsidized 
+      tuition and living stipend scholarships for tech training, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer 
+      adults, #BridgeTheTechGap, adult education, vocational training, workforce development, tech jobs, San Francisco, sf, Silicon Valley, Bay Area, 
+      remote learning, virtual, join tech, software engineering, learn to code, tech education, software developer school, web development, Michelle 
+      Glauser, become a software engineer"
     />
     <meta property="og:title" content="Techtonica: Bridging the Tech Gap" />
     <meta
       property="og:description"
-      content="Tuition-free tech training with living stipends and job placement at sponsoring companies for women and non-binary adults with low incomes."
+      content="Need-based, sliding-scale, subsidized tuition and living stipend scholarships and job placement at sponsoring companies for women and non-binary adults with low incomes."
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="http://techtonica.org" />

--- a/templates/board.html
+++ b/templates/board.html
@@ -13,10 +13,10 @@ Careers {% endblock title %} {% block content %}
     <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" title="Openings"
       >Openings</a></h1>
     <p class="justify">
-      Techtonica is a nonprofit that offers U.S. women and non-binary adults seeking 
-      economic empowerment free tech training, along with living and childcare stipends, then
-      places them in positions at sponsoring companies that are ready to support
-      more diverse teams or supports them during the job search. 
+      Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+      economic empowerment, need-based, sliding-scale, subsidized tuition and living stipend 
+      scholarships for tech training, then places them in positions at sponsoring companies 
+      that are ready to support more diverse teams or supports them during the job search. 
     </p>
     <div>
       <h3>Make an Impact as a Board Member!</h3>

--- a/templates/curriculumdev.html
+++ b/templates/curriculumdev.html
@@ -13,8 +13,8 @@ Careers {% endblock title %} {% block content %}
     <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" title="Openings"
       >Openings</a></h1>
     <p class="justify">
-      Techtonica is a nonprofit that offers six months of full-time software
-      engineering training with living stipends to Bay Area women and non-binary
+      Techtonica is a fiscally sponsored nonprofit that offers six months of full-time software
+      engineering training with living stipend scholarships to Bay Area women and non-binary
       adults with low incomes. After graduation, Techtonica places graduates
       into engineering jobs with sponsor companies. You can
       <a

--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -30,7 +30,7 @@ FAQs {% endblock title %} {% block content %}
       <li>
         88% of our participants so far have been
         <strong>people of color</strong>, 21% have a
-        <strong>disability</strong>, <strong>21% are parents
+        <strong>disability</strong>, 21% are <strong>parents
         </strong>, 10% identify <strong>outside the gender 
         binary</strong>, and 1% are <strong>veterans</strong>
       </li>

--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -7,15 +7,18 @@ FAQs {% endblock title %} {% block content %}
     <p>&nbsp;</p>
     <h3>What is your one-sentence description of Techtonica?</h3>
     <p id="unique">
-      Techtonica partners with tech companies to provide free tech training,
-      laptops, living stipends, and job placement to women and non-binary adults
-      seeking economic empowerment.
+      Techtonica partners with tech companies to provide need-based, sliding-scale, 
+      subsidized tuition and living stipend scholarships for tech training with supplied laptops, 
+      job placement and/or job search support to women and non-binary adults seeking 
+      economic empowerment.
     </p>
     <p>&nbsp;</p>
     <h3 id="different">What makes Techtonica different?</h3>
     <p>
-      We offer underserved, diverse populations an opportunity to be involved in a long-term, tuition-free, full-time program that prepares and places them in the software engineering field without having to worry about financial
-      instability. The main differences between us and other programs are:
+      We offer underserved, diverse populations an opportunity to be involved in a long-term, 
+      need-based, sliding-scale, subsidized tuition and living stipend scholarships for a full-time Tech 
+      program that prepares and places them in the software engineering field without having to worry
+      about financial instability. The main differences between us and other programs are:
     </p>
     <ul>
       <li>
@@ -25,17 +28,17 @@ FAQs {% endblock title %} {% block content %}
         tech skills
       </li>
       <li>
-        85% of our participants so far have been
-        <strong>people of color</strong>, 19% have a
-        <strong>disability</strong>, 8% identify
-        <strong>outside the gender binary</strong>, and 2% are
-        <strong>veterans</strong>
+        88% of our participants so far have been
+        <strong>people of color</strong>, 21% have a
+        <strong>disability</strong>, <strong>21% are parents
+        </strong>, 10% identify <strong>outside the gender 
+        binary</strong>, and 1% are <strong>veterans</strong>
       </li>
-      <li>Our program is <strong>free</strong> for participants</li>
+      <li>Our program offers <strong>need-based, sliding-scale, 
+        subsidized tuition and living stipend scholarships</strong> for participants</li>
       <li>
-        We provide stipends to help our participants with<strong>
-          living and childcare costs</strong
-        >
+        We provide living stipend scholarships to help our participants with<strong> 
+          living and childcare costs</strong> and lessen the pricing of tuition where eligible
       </li>
       <li>
         We are a <strong>nonprofit, so donations are tax-deductible</strong>

--- a/templates/full-time-program.html
+++ b/templates/full-time-program.html
@@ -5,13 +5,15 @@ endblock title %} {% block content %}
     <div class="main-header__text blue-background">
       <h1 class="main-header__header">Full-Time Program</h1>
       <p>
-        Six months of free, intensive, hands-on software engineering learning,
-        followed by six months of remote job placement or job search support for women and
-        non-binary adults seeking economic empowerment. The July 2024 cohort will be a five-month cohort.
+        Six months of need-based, sliding-scale, subsidized tuition and living 
+        stipend scholarships for intensive, hands-on software engineering learning,
+        followed by six months of remote job placement or job search support 
+        for women and non-binary adults seeking economic empowerment. The 
+        July 2024 cohort will be just five months, running from July to November. 
       </p>
       <h2>
         <a href="https://forms.gle/Y77pMRqRvSAyF2uT6"
-          class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Apply today!</a>
+          class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Apply by May 20th (12pm PT)!</a>
       </h2>
     </div>
   </div>
@@ -52,7 +54,7 @@ endblock title %} {% block content %}
       <p class="justify">
         As many companies have changed their priorities over the last few years, Techtonica 
         has had difficulty relying on a corporate sponsorship model. As a result, Techtonica 
-        is adopting a tuition-based model with need-based, sliding-scale, subsidized tuition and stipend 
+        is adopting a tuition-based model with need-based, sliding-scale, subsidized tuition and living stipend 
         scholarships to enable the program to serve more participants, in addition to continuing
         to seek sponsorships. Our H2 cohort in 2024 will take place from July to November instead 
         of July to December like in past years, with the last month of group placement prep 
@@ -70,8 +72,8 @@ endblock title %} {% block content %}
         If you will not have $18,000 beyond 10 months of living costs, you are eligible to apply 
         for a partial or full scholarship. If you will not be able to cover tuition or 10 months 
         of living costs, you are eligible to apply for a tuition scholarship as well as a monthly 
-        stipend. Only those determined to be in need of full scholarships will be considered for 
-        monthly stipends.
+        living stipend. Only those determined to be in need of full scholarships will 
+        be considered for monthly stipends.
       </p>
       <p class="justify">
         The program usually runs Monday through Friday, 8:00 AM to 5:00 PM (Pacific Time)
@@ -343,7 +345,7 @@ endblock title %} {% block content %}
         <h2>
           <!-- FT cohort application button that leads to short form -->
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform"
-          class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Apply today!</a>
+          class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Apply by May 20th (12pm PT)!</a>
           <!-- Uncomment when FT cohort application closes, comment apply today button above when application is closed
           <a href="https://www.eventbrite.com/o/techtonica-11297022451"
           class="sponsor" id="orange-button" target="_blank" rel="noopener noreferrer">Sign up to join our events</a>  -->

--- a/templates/home.html
+++ b/templates/home.html
@@ -14,7 +14,7 @@ endblock title %} {% block content %}
           id="orange-button"
           target="_blank"
           rel="noopener noreferrer"
-          >Apply now!</a
+          >Apply by May 20th (12pm PT)!</a
         >
       </h2>
     </div>

--- a/templates/news.html
+++ b/templates/news.html
@@ -631,11 +631,18 @@ endblock title %} {% block content %}
         </p>
         <p class="press-release-bold">About Techtonica</p>
         <p>
-          Founded in 2016 by Michelle Glauser, Techtonica is a software
-          engineering program based in San Francisco that partners with tech
-          companies to provide free, intensive tech training and job placement
-          specifically for Bay Area women and non-binary adults who have low
-          incomes. Learn more at techtonica.org.
+          <p>
+            Founded in 2016 by Michelle Glauser, Techtonica began as a software
+            engineering program based in San Francisco that partners with tech
+            companies to provide free, intensive tech training and job placement
+            specifically for Bay Area women and non-binary adults who have low
+            incomes.Learn more at 
+          <a
+            href="https://techtonica.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+            >techtonica.org</a
+          >.
         </p>
       </div>
     </li>
@@ -678,11 +685,12 @@ endblock title %} {% block content %}
         </p>
         <p class="press-release-bold">About Techtonica</p>
         <p>
-          Founded in 2016 by Michelle Glauser, Techtonica is a software
-          engineering program based in San Francisco that partners with tech
-          companies to provide free, intensive tech training and job placement
-          specifically for Bay Area women and non-binary adults who have low
-          incomes. Learn more at
+          <p>
+            Founded in 2016 by Michelle Glauser, Techtonica began as a software
+            engineering program based in San Francisco that partners with tech
+            companies to provide free, intensive tech training and job placement
+            specifically for Bay Area women and non-binary adults who have low
+            incomes.Learn more at 
           <a
             href="https://techtonica.org/"
             target="_blank"
@@ -760,11 +768,12 @@ endblock title %} {% block content %}
         </p>
         <p class="press-release-bold">About Techtonica</p>
         <p>
-          Founded in 2016 by Michelle Glauser, Techtonica is a software
-          engineering program based in San Francisco that partners with tech
-          companies to provide free, intensive tech training and job placement
-          specifically for Bay Area women and non-binary adults who have low
-          incomes. Learn more at
+          <p>
+            Founded in 2016 by Michelle Glauser, Techtonica began as a software
+            engineering program based in San Francisco that partners with tech
+            companies to provide free, intensive tech training and job placement
+            specifically for Bay Area women and non-binary adults who have low
+            incomes.Learn more at 
           <a
             href="https://techtonica.org/"
             target="_blank"

--- a/templates/openings.html
+++ b/templates/openings.html
@@ -17,10 +17,10 @@
     <div class="column">
       <h1 class="blue-h1">Openings</h1>
       <p class="justify">
-        Techtonica is a nonprofit that offers women and non-binary adults with low
-        incomes free tech training, along with living and childcare stipends, then
-        places them in positions at sponsoring companies that are ready to support
-        more diverse teams.
+        Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+        economic empowerment, need-based, sliding-scale, subsidized tuition and living stipend 
+        scholarships for tech training, then places them in positions at sponsoring companies 
+        that are ready to support more diverse teams or supports them during the job search.
       </p>
       <p class="justify"></p>
       <!-- <h3>No openings at the moment; please check back later</h3> -->

--- a/templates/partnershipsmanager.html
+++ b/templates/partnershipsmanager.html
@@ -18,10 +18,10 @@
       <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" title="Openings"
         >Openings</a></h1>
       <p class="justify">
-        Techtonica is a fiscally-sponsored nonprofit that helps U.S. women and 
-        non-binary adults with low incomes overcome barriers into tech careers by
-        providing free tech training, laptops, stipends, and job placement and 
-        support through corporate sponsorships.
+        Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+        economic empowerment, need-based, sliding-scale, subsidized tuition and living stipend 
+        scholarships for tech training, then places them in positions at sponsoring companies 
+        that are ready to support more diverse teams or supports them during the job search. 
       </p>
 
       <h3>Make an Impact as Our Partnerships Manager!</h3>

--- a/templates/stem.html
+++ b/templates/stem.html
@@ -13,10 +13,10 @@ Careers {% endblock title %} {% block content %}
     <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" 
       title="Openings">Openings</a></h1>
     <p class="justify">
-      Techtonica is a nonprofit (through fiscal sponsor Social Good Fund) that
-      offers women and non-binary adults seeking economic empowerment free tech training,
-      along with living and childcare stipends, then places them in positions at
-      sponsoring companies.
+      Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+      economic empowerment, need-based, sliding-scale, subsidized tuition and living stipend 
+      scholarships for tech training, then places them in positions at sponsoring companies 
+      that are ready to support more diverse teams or supports them during the job search. 
     </p>
     <h3>Make an Impact as Our Software Training Engineering Manager (Remote U.S.)</h3>
 

--- a/templates/tapm.html
+++ b/templates/tapm.html
@@ -13,9 +13,10 @@ Careers {% endblock title %} {% block content %}
     <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" title="Openings"
       >Openings</a></h1>
     <p class="justify">
-      Techtonica is a nonprofit that helps women and non-binary adults with low
-      incomes overcome barriers into the tech industry by providing laptops,
-      stipends, technical training, and placements.
+      Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+      economic empowerment, need-based, sliding-scale, subsidized tuition and living stipend 
+      scholarships for tech training, then places them in positions at sponsoring companies 
+      that are ready to support more diverse teams or supports them during the job search.
     </p>
     <h3>Make an Impact as Our Technical Associate Program Manager</h3>
 


### PR DESCRIPTION
Changed program description across website overall for terms stating "stipend", "free", and "apply now."

Other changes include: 
- updating the statistics on the FAQ page
- adding the words "fiscally sponsored" to the program summary sentences
- add closing date to the "apply now" buttons
- remove "childcare" from "living and childcare stipends" in some areas and change to "living stipend scholarships"