### PR TITLE
Remove sponsorship lead from job openings page

### DIFF
--- a/templates/openings.html
+++ b/templates/openings.html
@@ -25,11 +25,6 @@
       <p class="justify"></p>
       <!-- <h3>No openings at the moment; please check back later</h3> -->
       <p>
-        <a href="{{ url_for('render_sponsorshipslead_page') }}">
-          <h3>Sponsorships Lead</h3>
-        </a>
-      </p>
-      <p>
         <a href="{{ url_for('render_board_page') }}">
           <h3>Advisory Board Member (Volunteer Role)</h3>
         </a>


### PR DESCRIPTION
# Before
<img width="951" alt="Screenshot 2024-08-12 at 5 08 58 PM" src="https://github.com/user-attachments/assets/9c296c51-eac9-418d-8fa7-33be474ef971">

# After
<img width="938" alt="Screenshot 2024-08-12 at 5 08 33 PM" src="https://github.com/user-attachments/assets/6ffb0d97-cb1c-4f89-9d5c-005375d420f1">
