### PR TITLE
Add Mastodon link to FAQ

### DIFF
--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -311,6 +311,12 @@ FAQs {% endblock title %} {% block content %}
           title="Facebook"
           >Facebook</a
         >,
+        <a href="https://hachyderm.io/@Techtonica"
+          target="_blank"
+          title="Mastodon (Hachyderm)"
+          rel="me"
+          >Mastodon (Hachyderm)</a
+        >,
         <a href="https://medium.com/techtonica/" target="_blank" title="Medium">Medium</a>, and
         <a href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg"
           target="_blank"


### PR DESCRIPTION
This commit adds a link to our new Mastodon account on Hachyderm with the rel="me" attribute that will allow us to be verified as a corporate account.