### PR TITLE
Resize all team images to be square

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -284,8 +284,10 @@ button {
 }
 
 .resize-200px {
-  max-height: 200px;
-  max-width: 200px;
+  /* Ensure each teams image is square */
+  object-fit: cover;
+  width: 230px;
+  height: 230px;
 }
 
 .margin-25 {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -286,8 +286,8 @@ button {
 .resize-200px {
   /* Ensure each teams image is square */
   object-fit: cover;
-  width: 230px;
-  height: 230px;
+  width: 200px;
+  height: 200px;
 }
 
 .margin-25 {


### PR DESCRIPTION
This addresses issue #364. Adjusted the css to resize images with class `resize-200px` to be more square specific by adding the following properties: 

```
.resize-200px {
  /* Ensure each teams image is square */
  object-fit: cover;
  width: 230px;
  height: 230px;
}
```

## Before
<img width="1181" alt="Screenshot 2024-10-30 at 11 48 56 AM" src="https://github.com/user-attachments/assets/0815c938-ca72-4253-bf8b-914a481d43a8">

## After
<img width="1177" alt="Screenshot 2024-10-30 at 11 49 22 AM" src="https://github.com/user-attachments/assets/f8e71737-4e19-4e72-bda5-997b7c36ad81">
