### PR TITLE
Align team page images and spacing at the bottom of page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -97,6 +97,10 @@ button {
   align-items: center;
 }
 
+.staff-team {
+  align-items: flex-start;
+}
+
 .row__baseline {
   align-items: baseline;
 }

--- a/templates/team.html
+++ b/templates/team.html
@@ -332,8 +332,6 @@ About Us {% endblock title %} {% block content %}
       </p>
     </div>
   </div>
-  <div class="row">
-  </div>
 </div>
 
 <!--section for original picture and paragraph-->

--- a/templates/team.html
+++ b/templates/team.html
@@ -35,8 +35,8 @@ About Us {% endblock title %} {% block content %}
     </div>
     <div class="column centered">
       <img
-        src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
-        alt="Joy Sau"
+        src="{{ url_for('static', filename='img/Daaimah-Tibrey-min.png') }}"
+        alt="Daaimah Tibrey"
         class="resize-200px"
       />
       <footer>
@@ -44,17 +44,26 @@ About Us {% endblock title %} {% block content %}
           href="https://www.linkedin.com/in/daaimah123/"
           target="_blank"
           rel="noopener noreferrer"
-          >Joy Sau (she/her), <br/>Administrative Assistant
+          >Daaimah Tibrey (she/her), <br/>
+          Software Training Engineering Manager (STEM)
         </a>
       </footer>
       <p class="justify">
-        Joy has a background in project management and health. She is passionate 
-        about mental health and general well–being, and believes everyone deserves 
-        a chance to showcase their skills and talents. Having worked with different 
-        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
-        research, writing reports and summaries, collaborating remotely, providing 
-        customer care, and doing other project-related tasks. Working with Techtonica 
-        has given her a platform to make many lives better.
+        As a queer, black, disabled, primary caregiver, Daaimah faced many barriers 
+        simply entering the tech industry and when getting into her first technical role; 
+        she discovered it was a whole new beast compared to her past work in the grassroots 
+        nonprofit world: writing grants, managing programs, supporting equity and inclusion 
+        through public policy education, and advising persons with disabilities on careers. 
+        Following completion of the Techtonica program in 2019, she worked at SurveyMonkey 
+        as a software engineer, tech lead at Hack The Hood, and technical career counselor 
+        with Code Tenderloin. Wanting to pay it forward, Daaimah volunteered as a graduate 
+        board member and mentor program manager at Techtonica until she was hired as the 
+        Software Training Engineering Manager at Techtonica, where she now utilizes the 
+        skill sets in her arsenal to advocate for mindful accommodations, training access, 
+        and new pathways to entry for underrepresented intersectionalities in the tech 
+        space. She grew up and still resides in the Bay Area. For kicks, she enjoys hitting 
+        the trails with her two children and two dogs, as well as learning about science 
+        and anthropology.
       </p>
     </div>
   </div>
@@ -81,8 +90,8 @@ About Us {% endblock title %} {% block content %}
     </div>
     <div class="column centered">
        <img
-          src="{{ url_for('static', filename='img/Daaimah-Tibrey-min.png') }}"
-          alt="Daaimah Tibrey"
+          src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
+          alt="Joy Sau"
           class="resize-200px"
         />
       <footer>
@@ -90,26 +99,18 @@ About Us {% endblock title %} {% block content %}
           href=""
           target="_blank"
           rel="noopener noreferrer"
-          >Daaimah Tibrey (she/her), <br/>
-          Software Training Engineering Manager (STEM)
+          >Joy Sau (she/her), <br/>
+          Administrative Assistant
         </a>
       </footer>
       <p class="justify">
-        As a queer, black, disabled, primary caregiver, Daaimah faced many barriers 
-        simply entering the tech industry and when getting into her first technical role; 
-        she discovered it was a whole new beast compared to her past work in the grassroots 
-        nonprofit world: writing grants, managing programs, supporting equity and inclusion 
-        through public policy education, and advising persons with disabilities on careers. 
-        Following completion of the Techtonica program in 2019, she worked at SurveyMonkey 
-        as a software engineer, tech lead at Hack The Hood, and technical career counselor 
-        with Code Tenderloin. Wanting to pay it forward, Daaimah volunteered as a graduate 
-        board member and mentor program manager at Techtonica until she was hired as the 
-        Software Training Engineering Manager at Techtonica, where she now utilizes the 
-        skill sets in her arsenal to advocate for mindful accommodations, training access, 
-        and new pathways to entry for underrepresented intersectionalities in the tech 
-        space. She grew up and still resides in the Bay Area. For kicks, she enjoys hitting 
-        the trails with her two children and two dogs, as well as learning about science 
-        and anthropology.
+        Joy has a background in project management and health. She is passionate 
+        about mental health and general well–being, and believes everyone deserves 
+        a chance to showcase their skills and talents. Having worked with different 
+        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
+        research, writing reports and summaries, collaborating remotely, providing 
+        customer care, and doing other project-related tasks. Working with Techtonica 
+        has given her a platform to make many lives better.
       </p>
     </div>
   </div>

--- a/templates/team.html
+++ b/templates/team.html
@@ -35,8 +35,8 @@ About Us {% endblock title %} {% block content %}
     </div>
     <div class="column centered">
       <img
-        src="{{ url_for('static', filename='img/Daaimah-Tibrey-min.png') }}"
-        alt="Daaimah Tibrey"
+        src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
+        alt="Joy Sau"
         class="resize-200px"
       />
       <footer>
@@ -44,26 +44,17 @@ About Us {% endblock title %} {% block content %}
           href="https://www.linkedin.com/in/daaimah123/"
           target="_blank"
           rel="noopener noreferrer"
-          >Daaimah Tibrey (she/her), <br/>
-          Software Training Engineering Manager (STEM)</a
-        >
+          >Joy Sau (she/her), <br/>Administrative Assistant
+        </a>
       </footer>
       <p class="justify">
-        As a queer, black, disabled, primary caregiver, Daaimah faced many barriers 
-        simply entering the tech industry and when getting into her first technical role; 
-        she discovered it was a whole new beast compared to her past work in the grassroots 
-        nonprofit world: writing grants, managing programs, supporting equity and inclusion 
-        through public policy education, and advising persons with disabilities on careers. 
-        Following completion of the Techtonica program in 2019, she worked at SurveyMonkey 
-        as a software engineer, tech lead at Hack The Hood, and technical career counselor 
-        with Code Tenderloin. Wanting to pay it forward, Daaimah volunteered as a graduate 
-        board member and mentor program manager at Techtonica until she was hired as the 
-        Software Training Engineering Manager at Techtonica, where she now utilizes the 
-        skill sets in her arsenal to advocate for mindful accommodations, training access, 
-        and new pathways to entry for underrepresented intersectionalities in the tech 
-        space. She grew up and still resides in the Bay Area. For kicks, she enjoys hitting 
-        the trails with her two children and two dogs, as well as learning about science 
-        and anthropology.
+        Joy has a background in project management and health. She is passionate 
+        about mental health and general well–being, and believes everyone deserves 
+        a chance to showcase their skills and talents. Having worked with different 
+        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
+        research, writing reports and summaries, collaborating remotely, providing 
+        customer care, and doing other project-related tasks. Working with Techtonica 
+        has given her a platform to make many lives better.
       </p>
     </div>
   </div>
@@ -90,8 +81,8 @@ About Us {% endblock title %} {% block content %}
     </div>
     <div class="column centered">
        <img
-          src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
-          alt="Joy Sau"
+          src="{{ url_for('static', filename='img/Daaimah-Tibrey-min.png') }}"
+          alt="Daaimah Tibrey"
           class="resize-200px"
         />
       <footer>
@@ -99,17 +90,26 @@ About Us {% endblock title %} {% block content %}
           href=""
           target="_blank"
           rel="noopener noreferrer"
-          >Joy Sau (she/her), <br/>Administrative Assistant
+          >Daaimah Tibrey (she/her), <br/>
+          Software Training Engineering Manager (STEM)
         </a>
       </footer>
       <p class="justify">
-        Joy has a background in project management and health. She is passionate 
-        about mental health and general well–being, and believes everyone deserves 
-        a chance to showcase their skills and talents. Having worked with different 
-        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
-        research, writing reports and summaries, collaborating remotely, providing 
-        customer care, and doing other project-related tasks. Working with Techtonica 
-        has given her a platform to make many lives better.
+        As a queer, black, disabled, primary caregiver, Daaimah faced many barriers 
+        simply entering the tech industry and when getting into her first technical role; 
+        she discovered it was a whole new beast compared to her past work in the grassroots 
+        nonprofit world: writing grants, managing programs, supporting equity and inclusion 
+        through public policy education, and advising persons with disabilities on careers. 
+        Following completion of the Techtonica program in 2019, she worked at SurveyMonkey 
+        as a software engineer, tech lead at Hack The Hood, and technical career counselor 
+        with Code Tenderloin. Wanting to pay it forward, Daaimah volunteered as a graduate 
+        board member and mentor program manager at Techtonica until she was hired as the 
+        Software Training Engineering Manager at Techtonica, where she now utilizes the 
+        skill sets in her arsenal to advocate for mindful accommodations, training access, 
+        and new pathways to entry for underrepresented intersectionalities in the tech 
+        space. She grew up and still resides in the Bay Area. For kicks, she enjoys hitting 
+        the trails with her two children and two dogs, as well as learning about science 
+        and anthropology.
       </p>
     </div>
   </div>

--- a/templates/team.html
+++ b/templates/team.html
@@ -6,7 +6,7 @@ About Us {% endblock title %} {% block content %}
   <div class="column centered">
     <h1>Staff</h1>
   </div>
-  <div class="row row__center blue-background">
+  <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/Brienna-Klassen-min.png') }}"
@@ -59,7 +59,7 @@ About Us {% endblock title %} {% block content %}
     </div>
   </div>
 
-  <div class="row row__center blue-background">
+  <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/Gabby-Moreno-min.png') }}"
@@ -113,7 +113,7 @@ About Us {% endblock title %} {% block content %}
       </p>
     </div>
   </div>
-    <div class="row row__center blue-background">
+    <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/maggie-fero-min.jpeg') }}"


### PR DESCRIPTION
This PR addresses issue #367 

Joy and Daaimah team members have been swapped because of the size of their content across their respective row. The last team row (following board members) was also removed as it had no content, but styling with padding / margin created extra spacing that was not desired.

## Before
![before](https://github.com/user-attachments/assets/e896538d-3244-4114-8fce-fa9b649a1264)

## After
![after](https://github.com/user-attachments/assets/43e85cce-7a85-4c22-94e8-57b492c06890)
