### PR TITLE
Adjust large screen sponsor page images and chart

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -260,10 +260,10 @@ button {
 
   @media screen and (min-width: 2881px) {
     .full-width-img {
-      width: 2880px !important;
-      height: auto !important;
-      margin-left: auto !important;
-      margin-right: auto !important;
+      width: 2880px;
+      height: auto;
+      margin-left: auto;
+      margin-right: auto;
   }    
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -197,8 +197,15 @@ button {
 
 #myChart {
   display: block;
-  width: 700px;
-  height: 350px;
+  max-width: 100%;
+  height: auto;
+}
+
+@media screen and (max-width: 2880px) {
+  #myChart {
+    width: 2880px;
+    height: 1800px;
+  }
 }
 
 .main-header__header {
@@ -247,6 +254,17 @@ button {
 
 .full-width-img {
   width: 100%;
+  max-width: 2440px;
+  height: auto;
+}
+
+  @media screen and (min-width: 2881px) {
+    .full-width-img {
+      width: 2880px !important;
+      height: auto !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+  }    
 }
 
 .forty-percent-width {

--- a/static/js/piechart.js
+++ b/static/js/piechart.js
@@ -22,47 +22,39 @@ let myChart = new Chart(ctx, {
   type: "pie",
   data: {
     labels: labels,
-
-    datasets: [
-      {
-        label: "Techtonica Demographics",
-        backgroundColor: colorHex,
-        data: [22, 24, 19, 12, 14, 7, 2],
-      },
-    ],
+    datasets: [{
+      label: "Techtonica Demographics",
+      backgroundColor: colorHex,
+      data: [22, 24, 19, 12, 14, 7, 2],
+    }],
   },
-
   options: {
     responsive: true,
-    maintainAspectRatio: true,
+    maintainAspectRatio: false, // Changed this line
     legend: {
       display: true,
       position: "bottom",
-      size: 40,
+      align: "center",
       labels: {
         fontColor: "#ffffff",
       },
     },
-    label: {
-      display: true,
-    },
-
     plugins: {
       datalabels: {
         color: "#fff",
-        anchor: "end",
-        align: "start",
-        offset: -3,
+        anchor: "center",
+        align: "center",
+        offset: 0,
         borderWidth: 2,
         borderColor: "#fff",
         borderRadius: 25,
-        clip: "false",
+        clip: false,
         backgroundColor: (context) => {
           return context.dataset.backgroundColor;
         },
         font: {
           weight: "bold",
-          size: 10,
+          size: 16, // Increased font size
         },
         formatter: (value, context) => {
           return value + "%";
@@ -71,3 +63,22 @@ let myChart = new Chart(ctx, {
     },
   },
 });
+
+// Function to resize the chart
+function resizeChart() {
+  let canvas = document.getElementById("myChart");
+  let width = Math.min(2880, window.innerWidth);
+  let height = Math.min(1800, window.innerHeight);
+
+  canvas.style.width = width + 'px';
+  canvas.style.height = height + 'px';
+
+  // Update chart size
+  myChart.resize();
+}
+
+// Initial resize
+resizeChart();
+
+// Resize on window resize
+window.addEventListener('resize', resizeChart);

--- a/static/js/piechart.js
+++ b/static/js/piechart.js
@@ -30,7 +30,7 @@ let myChart = new Chart(ctx, {
   },
   options: {
     responsive: true,
-    maintainAspectRatio: false, // Changed this line
+    maintainAspectRatio: false,
     legend: {
       display: true,
       position: "bottom",

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -150,11 +150,10 @@
 
 @media screen and (min-width: 2881px) {
   .full-width-img {
-    width: 2880px;
-    height: auto;
-    margin-left: auto;
-    margin-right: auto;
-    background-color: red; /* Temporary for testing */
+    width: 2880px !important;
+    height: auto !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
   }
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -152,6 +152,8 @@
   .full-width-img {
     width: 2880px;
     height: auto;
+    margin-left: auto;
+    margin-right: auto;
   }
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -147,14 +147,11 @@
     height: auto;
 
     @media screen and (min-width: 2881px) {
-      #sponsor-table-img {
         width: 2880px !important;
         height: auto !important;
         margin-left: auto !important;
         margin-right: auto !important;
-      }
     }    
-
 }
 
 .full-width-img {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -144,18 +144,18 @@
 
 .full-width-img {
   width: 100%;
-  max-width: 2880px;
+  max-width: 2440px;
   height: auto;
 }
 
-@media screen and (min-width: 2881px) {
-  .full-width-img {
-    width: 2880px !important;
-    height: auto !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
-}
+// @media screen and (min-width: 2881px) {
+//   .full-width-img {
+//     width: 2880px !important;
+//     height: auto !important;
+//     margin-left: auto !important;
+//     margin-right: auto !important;
+//   }
+// }
 
 .forty-percent-width {
   width: 40%;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -145,11 +145,13 @@
 .full-width-img {
   width: 100%;
   max-width: 2880px;
+  height: auto;
 }
 
-@media screen and (max-width: 2880px) {
-  .element {
-    width: 100%;
+@media screen and (min-width: 2881px) {
+  .full-width-img {
+    width: 2880px;
+    height: auto;
   }
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -144,6 +144,13 @@
 
 .full-width-img {
   width: 100%;
+  max-width: 2880px;
+}
+
+@media screen and (max-width: 2880px) {
+  .element {
+    width: 100%;
+  }
 }
 
 .forty-percent-width {

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -142,20 +142,25 @@
   width: 100%;
 }
 
-.full-width-img {
-  width: 100%;
+#sponsor-table-img {
   max-width: 2440px;
   height: auto;
 }
 
-// @media screen and (min-width: 2881px) {
-//   .full-width-img {
-//     width: 2880px !important;
-//     height: auto !important;
-//     margin-left: auto !important;
-//     margin-right: auto !important;
-//   }
-// }
+@media screen and (min-width: 2881px) {
+  #sponsor-table-img {
+    width: 2880px !important;
+    height: auto !important;
+    margin-left: auto !important;
+    margin-right: auto !important;
+  }
+}
+
+.full-width-img {
+  width: 100%;
+  // max-width: 2440px;
+  // height: auto;
+}
 
 .forty-percent-width {
   width: 40%;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -154,6 +154,7 @@
     height: auto;
     margin-left: auto;
     margin-right: auto;
+    background-color: red; /* Temporary for testing */
   }
 }
 

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -142,32 +142,18 @@
   width: 100%;
 }
 
-#sponsor-table-img {
-    max-width: 2440px;
-    height: auto;
-
-    @media screen and (min-width: 2881px) {
-        width: 2880px !important;
-        height: auto !important;
-        margin-left: auto !important;
-        margin-right: auto !important;
-    }    
-}
-
 .full-width-img {
   width: 100%;
   max-width: 2440px;
   height: auto;
-}
 
-// @media screen and (min-width: 2881px) {
-//   .full-width-img {
-//     width: 2880px !important;
-//     height: auto !important;
-//     margin-left: auto !important;
-//     margin-right: auto !important;
-//   }
-// }
+  @media screen and (min-width: 2881px) {
+      width: 2880px !important;
+      height: auto !important;
+      margin-left: auto !important;
+      margin-right: auto !important;
+  }    
+}
 
 .forty-percent-width {
   width: 40%;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -143,24 +143,34 @@
 }
 
 #sponsor-table-img {
-  max-width: 2440px;
-  height: auto;
-}
+    max-width: 2440px;
+    height: auto;
 
-@media screen and (min-width: 2881px) {
-  #sponsor-table-img {
-    width: 2880px !important;
-    height: auto !important;
-    margin-left: auto !important;
-    margin-right: auto !important;
-  }
+    @media screen and (min-width: 2881px) {
+      #sponsor-table-img {
+        width: 2880px !important;
+        height: auto !important;
+        margin-left: auto !important;
+        margin-right: auto !important;
+      }
+    }    
+
 }
 
 .full-width-img {
   width: 100%;
-  // max-width: 2440px;
-  // height: auto;
+  max-width: 2440px;
+  height: auto;
 }
+
+// @media screen and (min-width: 2881px) {
+//   .full-width-img {
+//     width: 2880px !important;
+//     height: auto !important;
+//     margin-left: auto !important;
+//     margin-right: auto !important;
+//   }
+// }
 
 .forty-percent-width {
   width: 40%;

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -98,9 +98,15 @@
 }
 
 #myChart {
-  display: block;
-  width: 700px;
-  height: 350px;
+  max-width: 100%;
+  height: auto;
+}
+
+@media screen and (max-width: 2880px) {
+  #myChart {
+    width: 2880px;
+    height: 1800px;
+  }
 }
 
 .main-header__header {

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -36,7 +36,6 @@ endblock title %} {% block content %}
           src="{{ url_for('static', filename='img/partner-levels.png') }}"
           alt="Sponsor benefits chart"
           class="full-width-img"
-          id="sponsor-table-img"
         />
       </a>
       <h2>

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -36,6 +36,7 @@ endblock title %} {% block content %}
           src="{{ url_for('static', filename='img/partner-levels.png') }}"
           alt="Sponsor benefits chart"
           class="full-width-img"
+          id="sponsor-table-img"
         />
       </a>
       <h2>

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -132,7 +132,7 @@ endblock title %} {% block content %}
       <div> 
        <p>Techtonica Demographics:</p>
       </div> 
-      <canvas id="myChart" width="700" height="350"></canvas>
+      <canvas id="myChart"></canvas>
       </div>
     </div>
   <div class="row row__center">


### PR DESCRIPTION
This PR addresses issue #352 whereby the sponsors page chart image and the pie chart are very large on larger screen sizes. The following section's images still need to be addressed: 
- Techtonica Consulting
- How Hiring Works

[✅ Working] For the chart: To adjust the chart to have limited sizing of the image after `2880px` by `1800px` screen, we'll modify both the HTML and JavaScript parts; use CSS media queries to control the canvas size and update the `Chart.js` configuration to ensure proper scaling.

- removed the fixed `width` and `height` attributes from the canvas element in HTML.
- CSS media queries ensure that the canvas doesn't exceed `2880px` wide and `1800px` tall on screens larger than this size.
- set `maintainAspectRatio` to false in `Chart.js` options to allow independent scaling of `width` and `height`.
- function `resizeChart()` dynamically adjusts the canvas size based on the current window dimensions, capping at `2880x1800` pixels.
- call `myChart.resize()` after setting new dimensions to update the chart display.

[✅ Working] For the images: accomplished the change by limiting a `width: 100%` CSS rule from growing after `2880px`
- keep the base `.full-width-img` class with `width: 100%` and `max-width: 2880px`. This ensures the image takes full width on smaller screens and doesn't exceed `2880px` on larger ones.
- add a new media query that targets screens wider than `2880px` (`min-width: 2881px`).
- explicitly set the width to `2880px` for screens larger than `2880px` wide.
- keep `height: auto` to maintain the aspect ratio of the image.

## Before
<img width="1173" alt="Screenshot 2024-10-30 at 2 37 07 PM" src="https://github.com/user-attachments/assets/c2875dfa-869e-48a1-aa5e-65b9094b525c">
<img width="1475" alt="Screenshot 2024-10-30 at 5 05 13 PM" src="https://github.com/user-attachments/assets/f808bd2c-9bc5-492c-8bfb-a94082a2bf99">
<img width="1476" alt="Screenshot 2024-10-30 at 5 05 21 PM" src="https://github.com/user-attachments/assets/27e0ee29-4bc1-413d-a3bd-8175d17a62b8">

## After
<img width="1125" alt="Screenshot 2024-10-30 at 2 38 31 PM" src="https://github.com/user-attachments/assets/ff9fdf02-770e-4d62-aa41-bd4dca144d52">
<img width="1476" alt="Screenshot 2024-10-30 at 5 03 23 PM" src="https://github.com/user-attachments/assets/2891fee2-f6fd-4795-8c30-62d502edeeb8">
<img width="1475" alt="Screenshot 2024-10-30 at 5 03 41 PM" src="https://github.com/user-attachments/assets/82e3a60d-6239-48dc-ae32-4920551a4ea7">