### PR TITLE
Add meta description to base.html

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -7,6 +7,10 @@
       name="google-site-verification"
       content="SBEOwaB6Oumg3YDk1clhzVE3EeBmdzfsVTOve_iQIeg"
     />
+    <meta 
+      description="Techtonica helps women and non-binary adults overcome barriers into the tech industry and partner 
+      companies fulfill their diverse technical talent needs." 
+    />
     <!-- // This code block only needs to be installed once to activate all integrations site wide // Begin Flipcause Integration Code //--> -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <style>


### PR DESCRIPTION
Add a meta description to our base template so that tools looking for that specific tag to generate previews will pull our tagline instead of finding nothing and leaving it blank. 

earch engines will mostly pull content from the top of the page if it's missing, but some other tools (social media, SEO tools, tools that might otherwise suggest us to partners) sometimes only look for specifically the meta description tag. We don't currently have one, and this adds one.