### PR TITLE
Remove TA and add TA opening page

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -114,12 +114,20 @@ def render_openings_page():
 #     return render_template("stem.html")
 
 
-@app.route("/openings/tapm/")
-def render_tapm_page():
+# @app.route("/openings/tapm/")
+# def render_tapm_page():
+#     """
+#     Renders the TAPM page from jinja2 template
+#     """
+#     return render_template("tapm.html")
+
+@app.route("/openings/ta/")
+def render_ta_page():
     """
-    Renders the TAPM page from jinja2 template
+    Renders the TA page from jinja2 template
     """
-    return render_template("tapm.html")
+    return render_template("ta.html")
+
 
 # @app.route("/openings/partnershipsmanager/")
 # def render_partnershipsmanager_page():
@@ -135,12 +143,12 @@ def render_sponsorshipslead_page():
     """
     return render_template("sponsorshipslead.html")
 
-@app.route("/openings/curriculumdev/")
-def render_curriculumdev_page():
-    """
-    Renders the curriculum dev page from jinja2 template
-    """
-    return render_template("curriculumdev.html")
+# @app.route("/openings/curriculumdev/")
+# def render_curriculumdev_page():
+#     """
+#     Renders the curriculum dev page from jinja2 template
+#     """
+#     return render_template("curriculumdev.html")
 
 
 @app.route("/openings/board/")

--- a/templates/openings.html
+++ b/templates/openings.html
@@ -33,6 +33,9 @@
         <!-- <a href="{{ url_for('render_tapm_page') }}">
           <h3>Technical Associate Program Manager (TAPM)</h3>
         </a> -->
+        <!-- <a href="{{ url_for('render_ta_page') }}">
+          <h3>Technical Assistant (TA)</h3>
+        </a> -->
       </p>
       <div>{% include 'contactbutton.html' %}</div>
     </div>

--- a/templates/ta.html
+++ b/templates/ta.html
@@ -1,0 +1,155 @@
+{% extends "base.html" %} {% block title %} Techtonica: Bridging the Tech Gap —
+Careers {% endblock title %} {% block content %}
+<div class="row row__center about-us">
+  <div class="column hidden-med">
+    <img
+      src="{{ url_for('static', filename='img/make-a-difference-instructor.jpg') }}"
+      alt="A mentor works with a participant at a laptop."
+      class="fixed-img"
+      style="width: 38%"
+    />
+  </div>
+  <div class="column">
+    <h1 class="blue-h1"><a href="{{ url_for('render_openings_page') }}" title="Openings"
+      >Openings</a></h1>
+    <p class="justify">
+      Techtonica is a fiscally-sponsored nonprofit that offers U.S. women and non-binary adults seeking 
+      economic empowerment, software engineering training with need-based, sliding-scale, subsidized 
+      tuition and stipend scholarships, then places them in positions at sponsoring companies 
+      that are ready to support more diverse teams or supports them during the job search.
+    </p>
+    <h3>Make an Impact as Our Technical Assitant (TA)</h3>
+
+    <p class="justify">
+      Techtonica offers a life-changing learning experience to program
+      participants. We care deeply about helping our program participants become
+      high-quality developers.
+    </p>
+
+    <p class="justify">
+      We are looking for a self-motivated individual to start immediately as a
+      full-time Technical Assitant, starting at 15 hours weekly. This role would be a good opportunity for someone 
+      with JavaScript coding knowledge, especially if you are interested in 
+      focusing mostly on community organizing or program/project management.
+    </p>
+
+    <p class="justify">
+      <b
+        ><i
+          >We are normally located in San Francisco and most of our staff and
+          participants live in the Bay Area. The current cohort is virtual, so
+          this role is remote, but we need someone who can work during West
+          Coast hours (9-6 PM Pacific Time).</i
+        ></b
+      >
+    </p>
+
+    <p class="justify">
+      Our participants are women and non-binary adults and most of them are
+      people of color. We are seeking an individual who can relate to the target
+      audience on as many levels as possible.
+    </p>
+
+    <p class="justify">
+      This part-time role's compensation will start between $000 and $000
+      (depending on experience and location). We can provide benefits to
+      full-time employees, but we cannot provide visa sponsorship at this time.
+    </p>
+
+    <p class="justify">Responsibilities:</p>
+    <ul>
+      <li>Report to and collaborate with the program technical lead</li>
+      <li>
+        Cover technical topics with the cohort (this includes showing via live coding)
+      </li>
+      <li>Share your technical knowledge during meetings</li>
+      <li>Pair and debug with participants</li>
+      <li>
+        Update program materials as needed (instruction, schedules, notes, summaries,
+        assignments, schedules, etc.) that is up-to-date with full-stack
+        JavaScript best practices
+        <a href="https://github.com/Techtonica/curriculum/blob/master/README.md"
+          >some of the subjects we cover here</a
+        >
+      </li>
+      <li>Review code challenges with participants</li>
+      <li>Conduct technical office hours for the participants</li>
+      <li>Answer technical questions</li>
+      <li>Quiz participants to make sure they all know what they need to</li>
+      <li>
+        Identify the topics specific participants need stronger knowledge 
+        about, help them understand, connect them with helpful resources, 
+        and check that they’ve made improvement
+      </li>
+      <li>Other duties and responsibilities as assigned</li>
+    </ul>
+
+    <p class="justify">What we're looking for:</p>
+    <ul>
+      <li>Commitment to being at Techtonica for at least six months</li>
+      <li>Self-motivation and desire to make continual improvements</li>
+      <li>The ability to follow up with emails and other communication</li>
+      <li>The ability to work independently and asynchronously</li>
+      <li>Experience creating and maintaining online communities</li>
+      <li>
+        The ability to handle many different projects and tasks simultaneously
+        and independently
+      </li>
+      <li>
+        Excellent communication, interpersonal, trust-building, and leadership
+        skills
+      </li>
+      <li>
+        The ability to quickly familiarize yourself with Techtonica’s vision and
+        all people involved (staff, participants, board members, volunteers,
+        etc.)
+      </li>
+      <li>
+        Basic knowledge of web development (bonus points for full-stack
+        JavaScript)
+      </li>
+      <li>Strong moral values and discipline</li>
+      <li>Organization, commitment, and adaptability</li>
+      <li>
+        Understanding of socioeconomic experiences that our program participants
+        have faced
+      </li>
+      <li>Extroversion that is respectful of introversion</li>
+      <li>
+        Being passionate and informed about social justice and
+        diversity-and-inclusion-in-tech issues
+      </li>
+      <li>
+        The ability to relate to our target audience (women and non-binary
+        adults, mostly people of color, with low incomes) on as many levels as
+        possible
+      </li>
+      <li>Strong written communication skills in English</li>
+      <li>The ability to follow 
+        <a href="{{ url_for('render_conduct_page') }}" title="Code of Conduct" target="_blank"
+        rel="noopener noreferrer">
+        Techtonica's Code of Conduct
+        </a>
+      </li>
+    </ul>
+
+    <p>
+      The interview process involves showing you are a good fit for the role. We
+      may ask you to join us for an interview (online), contribute to the
+      curriculum, pair, and meet board members. Please send your resume or a
+      link to your LinkedIn profile and a link to your GitHub profile to both
+      dtibrey AT techtonica.org and info AT techtonica.org (in the same email) if this 
+      role sounds like a good fit for you.
+    </p>
+    <p></p>
+    <br />
+  </div>
+</div>
+<img
+  height="1"
+  width="1"
+  style="display: none"
+  alt=""
+  src="https://px.ads.linkedin.com/collect/?pid=1694756&conversionId=1681988&fmt=gif"
+/>
+{% endblock content %}

--- a/templates/ta.html
+++ b/templates/ta.html
@@ -51,7 +51,7 @@ Careers {% endblock title %} {% block content %}
     </p>
 
     <p class="justify">
-      This part-time role's compensation will start between $000 and $000
+      This part-time role's compensation will start between $30 and $35 an hour
       (depending on experience and location). We can provide benefits to
       full-time employees, but we cannot provide visa sponsorship at this time.
     </p>

--- a/templates/team.html
+++ b/templates/team.html
@@ -40,34 +40,34 @@ About Us {% endblock title %} {% block content %}
         and anthropology.
       </p>
     </div>
-    <div class="column centered">
-      <img
-         src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
-         alt="Joy Sau"
-         class="resize-200px"
-       />
-     <footer>
-       <a
-         href=""
-         target="_blank"
-         rel="noopener noreferrer"
-         >Joy Sau (she/her), <br/>
-         Administrative Assistant
-       </a>
-     </footer>
-     <p class="justify">
-       Joy has a background in project management and health. She is passionate 
-       about mental health and general well–being, and believes everyone deserves 
-       a chance to showcase their skills and talents. Having worked with different 
-       nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
-       research, writing reports and summaries, collaborating remotely, providing 
-       customer care, and doing other project-related tasks. Working with Techtonica 
-       has given her a platform to make many lives better.
-     </p>
-   </div>
   </div>
 
   <div class="row row__center blue-background staff-team">
+    <div class="column centered">
+       <img
+          src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
+          alt="Joy Sau"
+          class="resize-200px"
+        />
+      <footer>
+        <a
+          href=""
+          target="_blank"
+          rel="noopener noreferrer"
+          >Joy Sau (she/her), <br/>
+          Administrative Assistant
+        </a>
+      </footer>
+      <p class="justify">
+        Joy has a background in project management and health. She is passionate 
+        about mental health and general well–being, and believes everyone deserves 
+        a chance to showcase their skills and talents. Having worked with different 
+        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
+        research, writing reports and summaries, collaborating remotely, providing 
+        customer care, and doing other project-related tasks. Working with Techtonica 
+        has given her a platform to make many lives better.
+      </p>
+    </div>
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/maggie-fero-min.jpeg') }}"
@@ -92,6 +92,7 @@ About Us {% endblock title %} {% block content %}
       </p>
     </div>
   </div>
+    <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/Michelle-Glauser-min.jpg') }}"
@@ -116,7 +117,6 @@ About Us {% endblock title %} {% block content %}
         going on walks with her fluffy dog.
       </p>
     </div> 
-  <div class="row row__center blue-background staff-team">
 </div>
 
 <!--section for board members-->

--- a/templates/team.html
+++ b/templates/team.html
@@ -9,32 +9,6 @@ About Us {% endblock title %} {% block content %}
   <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
-        src="{{ url_for('static', filename='img/Brienna-Klassen-min.png') }}"
-        alt="Brienna Klassen"
-        class="resize-200px"
-      />
-      <footer>
-        <a
-          href="https://www.linkedin.com/in/briennaklassen/"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Brienna Klassen (she/her/they/them), <br/>Technical Assistant</a>
-      </footer>
-      <p class="justify">
-        A Techtonica alumni, Brienna graduated from the 2021-H1 cohort and
-        kicked off her career as a software developer for Stack Overflow.
-        Prior to her time as a participant at Techtonica, Brienna was working
-        numerous odd jobs to make ends meet while studying graphic design and
-        computer science at City College of San Francisco. Knowing from
-        firsthand experience what a difference it can make to have alternative
-        and more supportive paths for career development, she is proud to
-        return to the program; only this time, she’s taken on the role of
-        Technical Program Manager. Outside of the career, Brie enjoys painting
-        and a wide array of other geeky hobbies.
-      </p>
-    </div>
-    <div class="column centered">
-      <img
         src="{{ url_for('static', filename='img/Daaimah-Tibrey-min.png') }}"
         alt="Daaimah Tibrey"
         class="resize-200px"
@@ -66,34 +40,34 @@ About Us {% endblock title %} {% block content %}
         and anthropology.
       </p>
     </div>
+    <div class="column centered">
+      <img
+         src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
+         alt="Joy Sau"
+         class="resize-200px"
+       />
+     <footer>
+       <a
+         href=""
+         target="_blank"
+         rel="noopener noreferrer"
+         >Joy Sau (she/her), <br/>
+         Administrative Assistant
+       </a>
+     </footer>
+     <p class="justify">
+       Joy has a background in project management and health. She is passionate 
+       about mental health and general well–being, and believes everyone deserves 
+       a chance to showcase their skills and talents. Having worked with different 
+       nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
+       research, writing reports and summaries, collaborating remotely, providing 
+       customer care, and doing other project-related tasks. Working with Techtonica 
+       has given her a platform to make many lives better.
+     </p>
+   </div>
   </div>
 
   <div class="row row__center blue-background staff-team">
-    <div class="column centered">
-       <img
-          src="{{ url_for('static', filename='img/Joy-Sau-min.png') }}"
-          alt="Joy Sau"
-          class="resize-200px"
-        />
-      <footer>
-        <a
-          href=""
-          target="_blank"
-          rel="noopener noreferrer"
-          >Joy Sau (she/her), <br/>
-          Administrative Assistant
-        </a>
-      </footer>
-      <p class="justify">
-        Joy has a background in project management and health. She is passionate 
-        about mental health and general well–being, and believes everyone deserves 
-        a chance to showcase their skills and talents. Having worked with different 
-        nonprofits, Joy has enjoyed helping processes flow smoothly by conducting 
-        research, writing reports and summaries, collaborating remotely, providing 
-        customer care, and doing other project-related tasks. Working with Techtonica 
-        has given her a platform to make many lives better.
-      </p>
-    </div>
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/maggie-fero-min.jpeg') }}"
@@ -118,7 +92,6 @@ About Us {% endblock title %} {% block content %}
       </p>
     </div>
   </div>
-    <div class="row row__center blue-background staff-team">
     <div class="column centered">
       <img
         src="{{ url_for('static', filename='img/Michelle-Glauser-min.jpg') }}"
@@ -143,6 +116,7 @@ About Us {% endblock title %} {% block content %}
         going on walks with her fluffy dog.
       </p>
     </div> 
+  <div class="row row__center blue-background staff-team">
 </div>
 
 <!--section for board members-->


### PR DESCRIPTION
Removed TA from teams page and add TA html page for new opening; 

Live on: 
- testing.techtonica.org/team 
- testing.techtonica.org/openings/ta

## Teams Page Before
![with ta ](https://github.com/user-attachments/assets/e0efa20c-5838-4e15-9bdb-720fc535b3a2)

## Teams Page After
![remove ta ](https://github.com/user-attachments/assets/21815e27-b9ea-4988-b4b1-b8b1cf0483f8)

## TA opening page (currently not listed openings page)
![ta opening](https://github.com/user-attachments/assets/561485a1-8601-442c-8bac-cd86a1fae31c)