### PR TITLE
December 2024 Footer Update Proposal

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -659,19 +659,6 @@
             </a>
           <a
             class="social-link"
-            href="https://medium.com/techtonica/"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Medium"
-            ><img
-              src="{{ url_for('static', filename='img/medium.png') }}"
-              class="social-media"
-              alt="Techtonica Medium Publication"
-              />
-              <span class="icon-text">Medium</span>
-            </a>
-          <a
-            class="social-link"
             href="https://www.youtube.com/channel/UCZHRjd_jS91oEj0ecJ0kZsg"
             target="_blank"
             rel="noopener noreferrer"

--- a/templates/base.html
+++ b/templates/base.html
@@ -691,14 +691,6 @@
               />
               <span class="icon-text">Code of Conduct</span>
             </a>
-          <a class="social-link" href="{{ url_for('render_faqs_page') }}" title="FAQs"
-            ><img
-              src="{{ url_for('static', filename='img/faqs-icon.png') }}"
-              class="social-media"
-              alt="Techtonica FAQs"
-              />
-              <span class="icon-text">FAQs</span>
-            </a>
           <a class="social-link" href="mailto:info@techtonica.org" title="Email"
             ><img
               src="{{ url_for('static', filename='img/mail-icon.png') }}"

--- a/templates/base.html
+++ b/templates/base.html
@@ -620,19 +620,6 @@
         <p class="centered social-links">
           <a
             class="social-link"
-            href="https://twitter.com/TechtonicaOrg"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Twitter"
-            ><img
-              src="{{ url_for('static', filename='img/twitter-blue.png') }}"
-              class="social-media"
-              alt="Techtonica Twitter"
-              />
-            <span class="icon-text">Twitter</span>
-            </a>
-          <a
-            class="social-link"
             href="https://www.linkedin.com/company/techtonica/"
             target="_blank"
             rel="noopener noreferrer"
@@ -643,6 +630,19 @@
               alt="Techtonica LinkedIn"
               />
               <span class="icon-text">Linkedin</span>
+            </a>
+          <a
+            class="social-link"
+            href="https://twitter.com/TechtonicaOrg"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Twitter"
+            ><img
+              src="{{ url_for('static', filename='img/twitter-blue.png') }}"
+              class="social-media"
+              alt="Techtonica Twitter"
+              />
+            <span class="icon-text">Twitter</span>
             </a>
           <a
             class="social-link"

--- a/templates/base.html
+++ b/templates/base.html
@@ -646,19 +646,6 @@
             </a>
           <a
             class="social-link"
-            href="https://www.facebook.com/Techtonica/"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Facebook"
-            ><img
-              src="{{ url_for('static', filename='img/facebook-blue.png') }}"
-              class="social-media"
-              alt="Techtonica Facebook"
-              />
-              <span class="icon-text">Facebook</span>
-            </a>
-          <a
-            class="social-link"
             href="https://www.instagram.com/TechtonicaOrg/"
             target="_blank"
             rel="noopener noreferrer"

--- a/templates/base.html
+++ b/templates/base.html
@@ -670,14 +670,6 @@
               />
               <span class="icon-text">YouTube</span>
             </a>
-          <a class="social-link" href="{{ url_for('render_conduct_page') }}" title="Code of Conduct"
-            ><img
-              src="{{ url_for('static', filename='img/code-of-conduct-blue.jpg') }}"
-              class="social-media"
-              alt="Techtonica Code of Conduct"
-              />
-              <span class="icon-text">Code of Conduct</span>
-            </a>
           <a class="social-link" href="mailto:info@techtonica.org" title="Email"
             ><img
               src="{{ url_for('static', filename='img/mail-icon.png') }}"
@@ -712,6 +704,14 @@
               alt="Techtonica Careers"
               />
               <span class="icon-text">Careers</span>
+            </a>
+          <a class="social-link" href="{{ url_for('render_conduct_page') }}" title="Code of Conduct"
+            ><img
+              src="{{ url_for('static', filename='img/code-of-conduct-blue.jpg') }}"
+              class="social-media"
+              alt="Techtonica Code of Conduct"
+              />
+              <span class="icon-text">Code of Conduct</span>
             </a>
         </p>
         <p class="centered">


### PR DESCRIPTION
This is a proposal PR to update the website footer with two issues in mind:

- the footer has become cluttered over time, as things have been gradually added and not as often revisited holistically, and
- the order of links in the footer does not give the most prominent positions to our most important or popular links.

I propose that we remove the Facebook, Medium, and FAQ links in the footer to reduce clutter. More information about why I chose these specific links for removal is in the commit details on each proposed change. I further propose that we move LinkedIn (our top social platform in terms of engagement) to the far left of the row and our Code of Conduct link to the far right end, so that those are the easiest links to spot at a glance.

This would improve both the overall number of links in the footer as well as their order. We're currently at 12 links, and ideal would be 7 or fewer (working memory limitation). 

This PR gets us down to 9 links, but I recommend a follow-on change consolidating **Careers**, **Email**, and **News** on a new "Organization" or similar page to get us to 7 without removing any of the quite-valuable remaining links. This PR is just for the easy part, though!