### PR TITLE
Create dependency range for fastapi and starlette reqs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ eventbrite==3.3.5
     # via -r requirements.in
 exceptiongroup==1.2.1
     # via anyio
-fastapi
+fastapi>=0.100.0,<0.120.0
     # via -r requirements.in
 flask==1.1.2
     # via
@@ -100,7 +100,7 @@ squareup==22.0.0.20220921
     # via -r requirements.in
 starkbank-ecdsa==1.1.0
     # via sendgrid
-starlette
+starlette>=0.37.2,<0.39.0
     # via fastapi
 tomli==2.0.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ squareup==22.0.0.20220921
     # via -r requirements.in
 starkbank-ecdsa==1.1.0
     # via sendgrid
-starlette==0.40.0
+starlette==0.38.0
     # via fastapi
 tomli==2.0.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ eventbrite==3.3.5
     # via -r requirements.in
 exceptiongroup==1.2.1
     # via anyio
-fastapi==0.110.1
+fastapi
     # via -r requirements.in
 flask==1.1.2
     # via
@@ -100,7 +100,7 @@ squareup==22.0.0.20220921
     # via -r requirements.in
 starkbank-ecdsa==1.1.0
     # via sendgrid
-starlette==0.38.0
+starlette
     # via fastapi
 tomli==2.0.1
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -100,7 +100,7 @@ squareup==22.0.0.20220921
     # via -r requirements.in
 starkbank-ecdsa==1.1.0
     # via sendgrid
-starlette==0.37.2
+starlette==0.40.0
     # via fastapi
 tomli==2.0.1
     # via


### PR DESCRIPTION
Attempting to resolve [Starlette Denial of service (DoS) via multipart/form-data](https://github.com/Techtonica/techtonica.org/security/dependabot/27). I changed the dependency `startlette` to 0.38.0 and 0.40.0 but that didn't work so I added a range for both dependencies instead to resolve the other `fastapi` dependency's requirement.
<img width="764" alt="Screenshot 2024-12-18 at 6 59 56 PM" src="https://github.com/user-attachments/assets/06606fd2-19bf-44f2-9144-09396063d342" />

I ran this change on testing and it seems to have worked.
