### PR TITLE
Remove specific cohort from mentor page cta

### DIFF
--- a/templates/mentor.html
+++ b/templates/mentor.html
@@ -191,7 +191,7 @@ Mentoring {% endblock title %} {% block content %}
       class="sponsor"
       id="orange-button"
       target="_blank"
-      >Apply to mentor the 2025 H1 cohort</a
+      >Apply to be a mentor during this cohort!</a
     >
   </div>
   <div class="column centered">


### PR DESCRIPTION
In effort to minimize the number of future small changes to the website during program application process, the proposal is to keep the mentor CTA generalize so that it works for each FT program cohort.

## Before
<img width="691" alt="Screenshot 2025-01-02 at 2 37 16 AM" src="https://github.com/user-attachments/assets/5b8343d3-c52a-422a-acd9-853cfadcfa47" />

## After
<img width="427" alt="Screenshot 2025-01-02 at 2 38 53 AM" src="https://github.com/user-attachments/assets/ed4bce11-544c-411c-a6db-df02ebe6ae49" />
