### PR TITLE
Move image down on consulting page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -260,7 +260,10 @@ button {
 #sponsor-hero {
   width: 100%;
 }
-
+#consulting-hero {
+  width: 100%;
+  padding-top: 5%;
+}
 .full-width-img {
   width: 100%;
   max-width: 2440px;

--- a/templates/consulting.html
+++ b/templates/consulting.html
@@ -2,11 +2,6 @@
     endblock title %} {% block content %}
     
     <div class="main-content">
-      <div class="sponsor-header"> 
-        <img
-          id="sponsor-hero" 
-          src="{{ url_for('static', filename='img/Partnerships-Manager-with-Participants-min.png') }}"
-        />
       </div>
       <div class="row row__center blue-background" style="padding: 0">
         <h2 class="large-white-text">Partner today to help #BridgeTheTechGap!</h2>
@@ -25,6 +20,10 @@
             overseen by a senior technical program manager, stands ready to deliver innovative and 
             effective solutions.
           </p>
+                <img
+                  id="consulting-hero" 
+                  src="{{ url_for('static', filename='img/Partnerships-Manager-with-Participants-min.png') }}"
+                />
           <h2>Program Highlights</h2>
           <p class="justify">
             <ul>


### PR DESCRIPTION
I realized as I was checking on something in VSCode this morning that I forgot to push the change where I moved the currently-too-large image down the consulting page a bit to ensure we have critical information above the fold. This change moves that image from the top to after the first chunk of content. (I agree that we should still also swap to a single zoom row longer-term)