### PR TITLE
Link consulting from sponsorships

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -260,7 +260,10 @@ button {
 #sponsor-hero {
   width: 100%;
 }
-
+#consulting-hero {
+  width: 100%;
+  padding-top: 5%;
+}
 .full-width-img {
   width: 100%;
   max-width: 2440px;

--- a/templates/consulting.html
+++ b/templates/consulting.html
@@ -2,11 +2,6 @@
     endblock title %} {% block content %}
     
     <div class="main-content">
-      <div class="sponsor-header"> 
-        <img
-          id="sponsor-hero" 
-          src="{{ url_for('static', filename='img/Partnerships-Manager-with-Participants-min.png') }}"
-        />
       </div>
       <div class="row row__center blue-background" style="padding: 0">
         <h2 class="large-white-text">Partner today to help #BridgeTheTechGap!</h2>
@@ -25,6 +20,10 @@
             overseen by a senior technical program manager, stands ready to deliver innovative and 
             effective solutions.
           </p>
+                <img
+                  id="consulting-hero" 
+                  src="{{ url_for('static', filename='img/Partnerships-Manager-with-Participants-min.png') }}"
+                />
           <h2>Program Highlights</h2>
           <p class="justify">
             <ul>

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -560,5 +560,6 @@ endblock title %} {% block content %}
       To share a job posting on an inclusive team with Techtonica graduates who have 0-5 years of experience, please click here.
     </a>
   </div>
+  <div class="row__center centered">Need this talent for your team, but no capacity to support junior devs right now? Check out <a href="{{ url_for('render_consulting_page') }}">Techtonica Consulting</a>!</div>
 </div>
 {% endblock content %}


### PR DESCRIPTION
Add a link to the new Consulting page at the bottom of the Sponsorships page to redirect people for whom sponsorship is not currently feasible

This branch was forked from #470 , so diffs you see here may be a superset of the full diff depending on PR review/merge order. Only the change on line 563 of templates/sponsor.html is actually unique to this PR. 470 should be merged first.