### PR TITLE
Update Python dependencies from 3.6 to 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,5 +38,5 @@ repos:
     hooks:
       - id: prettier
 default_language_version:
-  python: python3.6
+  python: python3.8
 minimum_pre_commit_version: "1.21"

--- a/.python-version
+++ b/.python-version
@@ -1,1 +1,1 @@
-techtonica
+3.8.10


### PR DESCRIPTION
### Description: ###
This PR updates the Python version used in the project from `3.6` to `3.8`. The following files have been updated as part of this change:

- `.pre-commit-config.yaml`: Updated `default_language_version` from `python3.6` to `python3.8`.
- `.python-version`: Updated to `3.8.10`.

We are currently running the website on Python **3.8.10**, but I’ve chosen to specify `python3.8` (without the patch version) for flexibility to use any future patch version (`3.8.x`) that includes security and bug fixes without needing to update the configuration for each minor release.
