### PR TITLE
Update YAML file to fix Prettier - Issue #498 1st Pull Request

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,3 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#testing after re-doing post commit .git/hook script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#testing
+#testing123

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
         types: [python]
         pass_filenames: false
         stages: [manual]
-  - repo: https://github.com/pre-commit/pycqa/isort
-    rev: 5.10.1
-    hooks:
-      - id: isort
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.10.1
+  #   hooks:
+  #     - id: isort
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,19 +11,19 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         exclude_types: ["xml"]
-  - repo: local
-    hooks:
-      - id: seed-isort-config
-        name: seed-isort-config
-        entry: bin/seed-isort-config.sh
-        language: script
-        types: [python]
-        pass_filenames: false
-        stages: [manual]
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
+  # - repo: local
+  #   hooks:
+  #     - id: seed-isort-config
+  #       name: seed-isort-config
+  #       entry: bin/seed-isort-config.sh
+  #       language: script
+  #       types: [python]
+  #       pass_filenames: false
+  #       stages: [manual]
+  # - repo: https://github.com/pycqa/isort
+  #   rev: 5.12.0
+  #   hooks:
+  #     - id: isort
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
@@ -40,4 +40,3 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#123

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,15 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         exclude_types: ["xml"]
-  # - repo: local
-  #   hooks:
-  #     - id: seed-isort-config
-  #       name: seed-isort-config
-  #       entry: bin/seed-isort-config.sh
-  #       language: script
-  #       types: [python]
-  #       pass_filenames: false
-  #       stages: [manual]
+  - repo: local
+    hooks:
+      - id: seed-isort-config
+        name: seed-isort-config
+        entry: bin/seed-isort-config.sh
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [manual]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -40,3 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
+#testing

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,10 @@ repos:
         types: [python]
         pass_filenames: false
         stages: [manual]
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 5.10.1
-  #   hooks:
-  #     - id: isort
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
@@ -40,3 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
+# testing a change

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#testing again
+#testing after re-doing post commit .git/hook script

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
       - id: check-hooks-apply
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-case-conflict
@@ -20,8 +20,8 @@ repos:
         types: [python]
         pass_filenames: false
         stages: [manual]
-  - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.7.0
+  - repo: https://github.com/pre-commit/pycqa/isort
+    rev: 5.10.1
     hooks:
       - id: isort
   - repo: https://github.com/python/black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,19 +11,19 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         exclude_types: ["xml"]
-  # - repo: local
-  #   hooks:
-  #     - id: seed-isort-config
-  #       name: seed-isort-config
-  #       entry: bin/seed-isort-config.sh
-  #       language: script
-  #       types: [python]
-  #       pass_filenames: false
-  #       stages: [manual]
-  # - repo: https://github.com/pycqa/isort
-  #   rev: 5.12.0
-  #   hooks:
-  #     - id: isort
+  - repo: local
+    hooks:
+      - id: seed-isort-config
+        name: seed-isort-config
+        entry: bin/seed-isort-config.sh
+        language: script
+        types: [python]
+        pass_filenames: false
+        stages: [manual]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/python/black
     rev: 20.8b1
     hooks:
@@ -40,3 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
+#added script to pre-commit file

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#make a change
+#123

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,4 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-#testing123
+#make a change

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,15 +11,15 @@ repos:
       - id: detect-private-key
       - id: mixed-line-ending
         exclude_types: ["xml"]
-  - repo: local
-    hooks:
-      - id: seed-isort-config
-        name: seed-isort-config
-        entry: bin/seed-isort-config.sh
-        language: script
-        types: [python]
-        pass_filenames: false
-        stages: [manual]
+  # - repo: local
+  #   hooks:
+  #     - id: seed-isort-config
+  #       name: seed-isort-config
+  #       entry: bin/seed-isort-config.sh
+  #       language: script
+  #       types: [python]
+  #       pass_filenames: false
+  #       stages: [manual]
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
@@ -40,4 +40,4 @@ repos:
 default_language_version:
   python: python3.8.10
 minimum_pre_commit_version: "1.21"
-# testing a change
+#testing again


### PR DESCRIPTION
 ## Description:
 
 On the develop branch, commits cannot be pushed seamlessly due to 'Prettier' formatting that happens after git push attempt.
 
 As per the instructions in Issue #498, I updated the yaml file in order to resolve the issue with Prettier adding a commit after attempting a git push. The goal is for prettier to make its formatting updated alongside the commit process and not inhibit developer from pushing changes in one go.
 
 ## Changes:
I updated the yaml file by changing the following:
            - pre-commit/hooks repository: Update to version v4.4.0, which is compatible with Python 3.8.10.
            - pycqa/isort repository: Change from mirrors-isort to pycqa/isort. Update to version 5.10.1, which is compatible with Python 3.8.10. 
            
⚠️ ‼️ Currently running into an issues reinstalling the pre-commit hooks. See the comment below. ⚠️ 

 ## Next Steps:
Once this branch updates are running smoothly, I will test move on to the next steps entailed in the issue description.

- "once your branch with upgrade to the file is pushed to remote, create a second new local branch (from develop), document what occurs when you try to add and push changes to that branch
- merge the remote branch (with the upgraded yaml file) into your new second branch, document what occurs when you try to add and push changes to that branch
- make another change to your second branch and document what occurs when you try to add and push changes to the branch (we are hoping to see no more formatting changes at this stage)
- create a third new local branch (from develop), do not make any changes before merging the remote branch (with the upgraded yaml file) into your new third branch, document what occurs when you try to add and push changes to that branch (we are hoping to see no more formatting changes at this stage)"