### PR TITLE
Updated Black to  v24.8.0, Click to v8.1.8 Resolving Issue #525

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/python/black
-    rev: 20.8b1
+    rev: 24.8.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
## Description
Due to a known issue with earlier versions of Black, where Click is no longer compatible this error occurs:

`ImportError: cannot import name '_unicodefun' from 'click'
`
(Please reference issue #525  for more details.)

## Changes
The version of Black was updated to 24.8.0 and Click was updated to 8.1.8.

## Why this change?
These updates will fix the above mentioned error that has been documented to stem from using an outdated version of Black. Rather than isolating the update to Click, I opted to update Black because this new version is described as solving the Click issue along with other upgrades.

## Testing
Post-update, the pre-commit hook files ran normally in my local environment.
