### PR TITLE
Change word "fraud" to "fraudulent" for the Venmo section of donate page

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -50,7 +50,7 @@ endblock title %} {% block content %}
         target="_blank"
         rel="noopener noreferrer"
         >Venmo your donation to @socialgoodfund (Social Good Fund Executive
-        Director Michael Pace, NOT the fraud socialgoodfunding account) and
+        Director Michael Pace, NOT the Fund socialgoodfunding account) and 
         indicate it's for Techtonica.</a
       >
     </h3>

--- a/templates/donate.html
+++ b/templates/donate.html
@@ -50,7 +50,7 @@ endblock title %} {% block content %}
         target="_blank"
         rel="noopener noreferrer"
         >Venmo your donation to @socialgoodfund (Social Good Fund Executive
-        Director Michael Pace, NOT the Fund socialgoodfunding account) and 
+        Director Michael Pace, NOT the fraudulent socialgoodfunding account) and 
         indicate it's for Techtonica.</a
       >
     </h3>


### PR DESCRIPTION
👉🏾 First time contributing to this repo? START HERE 👈🏾
To be added as a curriculum contributor and be assigned the related issue, please kindly complete our contributor steps in order to have your PR addressing this issue merged.

Page where problem found?
https://techtonica.org/donate/

Type of problem
Typo in the Venmo section of the Donate page (https://techtonica.org/donate/).


<img width="1680" alt="Screenshot 2025-02-19 at 11 05 50 PM" src="https://github.com/user-attachments/assets/ff033a25-7913-46f6-95d0-5e44dde538b2" />


Issue Description
The sentence currently reads:
"Venmo your donation to @socialgoodfund (Social Good Fund Executive Director Michael Pace, NOT the fraud socialgoodfunding account) and indicate it's for Techtonica."

The use of the word "fraud" seems incorrect and may be a typo. It is likely meant to say "fund" instead.

Suggested Solution
Update the sentence to:
"Venmo your donation to @socialgoodfund (Social Good Fund Executive Director Michael Pace, NOT the fund socialgoodfunding account) and indicate it's for Techtonica."

This correction ensures clarity and avoids potential confusion for donors.