### PR TITLE
Add favicon link and move it to the <head> section of your HTML code

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -8,8 +8,13 @@
       content="SBEOwaB6Oumg3YDk1clhzVE3EeBmdzfsVTOve_iQIeg"
     />
     <meta
-      description="Techtonica helps women and non-binary adults overcome barriers into the tech industry and partner 
+      description="Techtonica helps women and non-binary adults overcome barriers into the tech industry and partner
       companies fulfill their diverse technical talent needs."
+    />
+    <link
+      href="{{ url_for('static', filename='img/favicon.ico') }}"
+      rel="icon"
+      type="image/x-icon"
     />
     <!-- // This code block only needs to be installed once to activate all integrations site wide // Begin Flipcause Integration Code //-->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
@@ -717,15 +722,15 @@
     </title>
     <meta
       name="description"
-      content="We partner with tech companies to offer tech training, laptops, living and childcare stipend scholarships, and job placement to women and 
+      content="We partner with tech companies to offer tech training, laptops, living and childcare stipend scholarships, and job placement to women and
       non-binary adults with low incomes."
     />
     <meta
       name="keywords"
-      content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, software engineering training with need-based, 
-      sliding-scale, subsidized tuition and stipend scholarships, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer 
-      adults, #BridgeTheTechGap, adult education, vocational training, workforce development, tech jobs, San Francisco, sf, Silicon Valley, Bay Area, 
-      remote learning, virtual, join tech, software engineering, learn to code, tech education, software developer school, web development, Michelle 
+      content="Techtonica, coding school for women, coding academy, learn how to code, programming courses, software engineering training with need-based,
+      sliding-scale, subsidized tuition and stipend scholarships, coding, women's empowerment, education for women, LGBT, LGBTQIA+, non-binary adults, genderqueer
+      adults, #BridgeTheTechGap, adult education, vocational training, workforce development, tech jobs, San Francisco, sf, Silicon Valley, Bay Area,
+      remote learning, virtual, join tech, software engineering, learn to code, tech education, software developer school, web development, Michelle
       Glauser, become a software engineer"
     />
     <meta property="og:title" content="Techtonica: Bridging the Tech Gap" />
@@ -738,11 +743,6 @@
     <meta
       property="og:image"
       content="{{ url_for('static', filename='img/three-participants-at-laptops-min.jpg') }}"
-    />
-    <link
-      href="{{ url_for('static', filename='img/favicon.ico') }}"
-      rel="icon"
-      type="image/x-icon"
     />
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script


### PR DESCRIPTION
## Description  
The favicon was not visible in the browser tab, despite the favicon file being present. This problem was caused by the favicon link being placed incorrectly outside of the `<head>` section of the HTML document. Moving the favicon link to the `<head>` section resolved the issue and allowed the favicon to be displayed.

## Changes Made  
- Added the favicon link and moved it to the `<head>` section of the `base.html`

## Related Issue  
- Issue Number: #562 

## Type of Change  
- [x] Bug fix  

## Objective  
Fix the issue where the favicon icon at the top of the browser tab is no longer visible and is showing the default greyed-out globe. Ensure the Techtonica blue icon displays properly.

## Acceptance Criteria  
- [x] The favicon should be visible in all browsers and tabs where the site is loaded.  
- [x] The favicon icon should now appear as the Techtonica blue icon in the browser tab.  

## Visuals 

*Before*
<img width="258" alt="Image" src="https://github.com/user-attachments/assets/fd33f167-7266-419d-ba43-33bc25c8fab2" />

*After*

https://github.com/user-attachments/assets/63febb84-d5b6-4f9d-aed2-b5afa02ea3f3

## How to test  
1. Run file locally 

## Reviewers
@daaimah123, @ChasVanDav, @kaylahrose, @mx-ruthie, and @monikkaelyse please review the `base.html` where the change is made.
