### PR TITLE
Strict sponsor placement language & 2025 H2 references

### DIFF
--- a/templates/full-time-program.html
+++ b/templates/full-time-program.html
@@ -8,8 +8,8 @@ endblock title %} {% block content %}
         Hands on software engineering training with need-based, sliding-scale,
         subsidized tuition and stipend scholarships, followed by six months of
         remote job placement or job search support for women and non-binary
-        adults seeking economic empowerment. The 2025 H1 Cohort kicks off in
-        January.
+        adults seeking economic empowerment. The 2025 H2 Cohort kicks off in
+        July.
       </p>
       <h2>
         {% if times.app_open %}
@@ -95,12 +95,12 @@ endblock title %} {% block content %}
       a result, Techtonica is adopting a tuition-based model with need-based,
       sliding-scale, subsidized tuition and stipend scholarships to enable the
       program to serve more participants, in addition to continuing to seek
-      sponsorships. Our H1 cohort in 2025 will begin in January. It is possible
+      sponsorships. Our H2 cohort in 2025 will begin in July. It is possible
       that we will secure some placements for this cohort, but it is not
       guaranteed.
     </p>
     <p class="justify">
-      Tuition for the 2025 H1 cohort is $18,000. The total cost has been
+      Tuition for the 2025 H2 cohort is $18,000. The total cost has been
       subsidized to lower the price to an amount that is less expensive than
       other programs at a cost of $1,000 per week (from Hackbright at
       $1,075/week to General Assembly at $2,183/week). Tuition paid upfront
@@ -237,7 +237,9 @@ endblock title %} {% block content %}
         >our testimonials page</a
       >, and our info session.
     </p>
-    <div class="videowrapper">
+
+    <!-- Commenting out past info session video below, to be replaced with 2025 H2 Application Info Session -->
+    <!-- <div class="videowrapper">
       <iframe
         width="560"
         height="315"
@@ -248,12 +250,9 @@ endblock title %} {% block content %}
         referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen
       ></iframe>
-    </div>
-    <!-- Commenting out past info session video, to be replaced with 2025 H1 Application Info Session -->
+    </div> -->
+
     <br />
-    <!-- <div class="videowrapper ">
-        <iframe width="560" height="315" src="https://www.youtube.com/embed/VkuhwMT4b7A?si=piEC6i6ypgTzIrZK" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
-      </div> -->
 
     <div class="column">
       <img
@@ -329,7 +328,7 @@ endblock title %} {% block content %}
           full-time training and the following six months
         </li>
         <li>
-          are willing to live in the U.S. if required by placement company
+          are willing to live in the U.S. and relocate to the location of placement, if required by placement company
         </li>
         <li>have a U.S. bank account</li>
         <li>
@@ -440,7 +439,7 @@ endblock title %} {% block content %}
       interested folks go out, and forms close again around October. For the
       July to December ("H2") cohort, the application forms open, emails to
       interested folks go out, and forms close again around March. For the 2025
-      H1 cohort, applications open in September and close in October. The
+      H2 cohort, applications open in March and close in April. The
       application process continues for about four to five weeks after
       applications close, with candidates eliminated at each step of the
       process.

--- a/templates/full-time-program.html
+++ b/templates/full-time-program.html
@@ -328,7 +328,7 @@ endblock title %} {% block content %}
           full-time training and the following six months
         </li>
         <li>
-          are willing to live in the U.S. and relocate to the location of placement, if required by placement company
+          are willing to live in the U.S. and relocate to an in-person location of placement, if required by placement company
         </li>
         <li>have a U.S. bank account</li>
         <li>


### PR DESCRIPTION
## Description
Previously we did not have a hard requirement for needing to attend placement in person, but rather suggested a future possibility of our placement sponsors requiring graduates being able to attend their placement in person. This is now a hard requirement for 2025-H2 onward and the respective areas need to be updated.

Furthermore, references & dates for the 2025-H1 cohort have been adjusted to the incoming 2025-H2 cohort.

## Related Issue
- #635
- #640

## Type of Change
New policy clarification & reference 2025-H2 cohort

## Acceptance Criteria
- There are no 2025-H1 references on the FT page
- Ensure that 2025-H2 brief timelines mentioned are clear and make sense with incoming application timeline
- It is clear that if someone is placed with a sponsor that requires in person, that they are committed to relocating and working in-person

## Changes Made

#### Website changes
/full-time-program page

#### Non-Website Changes: 
FT Page Eligibility & Long Form Description: 
> "are willing to live in the U.S. and relocate to the location of placement, if required by placement company"

Seeker ([section 4](https://docs.google.com/document/d/1oafx-QvUKezIDnP2uP_OKpR2Ang5klGHqJasr8e2f2w/edit?usp=sharing)), Returning Graduate ([section 6](https://docs.google.com/document/d/1hqhfXUTWBKeLZhznXolN3QU8_CuK1mFZm0pvuV7KqeQ/edit?usp=sharing)), & Participant ([section 6](https://docs.google.com/document/d/1ZU1ZdWp3S0udb6kuEdRA3yRp3lngM4FSnQZO-_GHyls/edit?usp=sharing)) Agreements have had the following sentence added to the "Job Placement" section via suggestions in google docs. Info Session ([slide 33](https://docs.google.com/presentation/d/1eJ65l5k1BpNsBo24gQmXY4_-9nP4PGDAVX_GfLmZt58/edit#slide=id.ga7127deae8_0_111)), Application Workshop (slide 41), noted on [slide 55](https://docs.google.com/presentation/d/1wSqF9G2dj_29Y0A51bm03TTYz2NgstruFk_byFlVtnE/edit#slide=id.g315273aa6b4_1_3) of Graduation deck, Onboarding (slides [23](https://docs.google.com/presentation/d/1382GN5Qzy7x5rGuED6HdVIGPoS9oup7JoC1BoX3csH8/edit#slide=id.g33a6fea999e_0_169) & [55](https://docs.google.com/presentation/d/1382GN5Qzy7x5rGuED6HdVIGPoS9oup7JoC1BoX3csH8/edit#slide=id.g33a6fea999e_0_704) notes) have also been updated: 
> "Placed participants commit to relocating for in-person location if required by a company they are placed at. This is a hard requirement from some of our sponsors."

## How to test
Run locally and ensure that the FT page does not reference 2025-H1 cohort. 

## Deployment Notes (if applicable)
Not applicable