### PR TITLE
Homepage and FT Page need to be connected to new global variables (Resolving Issue #644)

### DIFF
--- a/templates/full-time-program.html
+++ b/templates/full-time-program.html
@@ -12,7 +12,7 @@ endblock title %} {% block content %}
         July.
       </p>
       <h2>
-        {% if timeline.APP_OPEN %}
+        {% if timeline.APP_OPEN_DATE %}
         <a
           href="https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform"
           class="sponsor"
@@ -328,7 +328,8 @@ endblock title %} {% block content %}
           full-time training and the following six months
         </li>
         <li>
-          are willing to live in the U.S. and relocate to an in-person location of placement, if required by placement company
+          are willing to live in the U.S. and relocate to an in-person location
+          of placement, if required by placement company
         </li>
         <li>have a U.S. bank account</li>
         <li>
@@ -439,10 +440,9 @@ endblock title %} {% block content %}
       interested folks go out, and forms close again around October. For the
       July to December ("H2") cohort, the application forms open, emails to
       interested folks go out, and forms close again around March. For the 2025
-      H2 cohort, applications open in March and close in April. The
-      application process continues for about four to five weeks after
-      applications close, with candidates eliminated at each step of the
-      process.
+      H2 cohort, applications open in March and close in April. The application
+      process continues for about four to five weeks after applications close,
+      with candidates eliminated at each step of the process.
     </p>
     <div class="row">
       <div class="column column-med centered">

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,14 +10,14 @@ endblock title %} {% block content %}
         talent needs.
       </p>
       <h2>
-        {% if timeline.APP_OPEN %}
+        {% if timeline.APP_OPEN_DATE %}
         <a
           href="{{ url_for('render_ft_program_page') }}"
           class="sponsor"
           id="orange-button"
           target="_blank"
           rel="noopener noreferrer"
-          >{{timeline.TEXT}}</a
+          >{{ timeline.TEXT }}</a
         >
         {% else %}
         <a


### PR DESCRIPTION
### 📝 Description
We created global variables (in dates.py file), to allow dynamic rendering of dates and text related to the Techtonica application timeline. Those variables were applied to the relevant places on the website including, the homepage, the full time program page, and the mentor page. However, the text on the homepage and full time program page were not rendering properly, according to the logic set in dates.py - generate_timeline_variables function. 

### 🔂 Changes Made
This pull request slightly refactors the code to accept the global variables controlling what text is generated whether the applications are open, extended, or closed. One change was made! Previously, the logic in each template page hinged on the APP_OPEN boolean variable. as seen below:

<img width="477" alt="Screenshot 2025-03-08 at 11 47 45 AM" src="https://github.com/user-attachments/assets/4a828fc8-e40e-48ad-9c98-c4b9cf6ad15b" />

However, this clashed with the logic in the generate_application_timeline function and was superfluous. So, I changed the logic to instead detect whether the APP_OPEN_DATE variable exists. 
<img width="405" alt="Screenshot 2025-03-08 at 11 59 11 AM" src="https://github.com/user-attachments/assets/32e42605-3882-4e39-bcce-26e269502362" />

### ⚙️ Related Issue
- Issue Number: #644 

###🍏 Type of Change
- Bug fix
- Refactoring


### 🎁 Acceptance Criteria TBD


### 🧰 New Environment Variables or Requirements

N/A

### 🧪 How to test

1. Copy/paste environment variables from .env.example to .env
2. Set the following variables to test behavior:
  - APP_OPEN_DATE
  - APP_OPEN
3. Run the website, and check that the text generates as expected:
  - While applications are closed "Apply Now!"
  - While applications are open "Apply by ..."

### 🚀 Deployment Notes (if applicable)

N/A

### 📸 Screenshots (if applicable)

After changing the logic to APP_OPEN_DATE, the pages render properly and follow the generate_application_timeline function rules.

BEFORE:

<img width="320" alt="Screenshot 2025-03-08 at 12 01 50 PM" src="https://github.com/user-attachments/assets/5f460e3d-3220-480f-af0c-bd52da09c3d0" />
<img width="510" alt="Screenshot 2025-03-08 at 12 00 51 PM" src="https://github.com/user-attachments/assets/f3d11f76-a5ab-4f31-bcdf-358864a6924a" />


AFTER:

<img width="429" alt="Screenshot 2025-03-08 at 12 02 01 PM" src="https://github.com/user-attachments/assets/bf549fa6-e9d2-48ab-9d56-54c5bfb59759" />
<img width="668" alt="Screenshot 2025-03-08 at 12 01 17 PM" src="https://github.com/user-attachments/assets/b20a55c1-cdf2-489a-a152-8f7c88d58833" />

<img width="256" alt="Screenshot 2025-03-08 at 11 59 47 AM" src="https://github.com/user-attachments/assets/37ad4fb5-95c3-48a5-8191-c3d507e6f097" />

### ✅ Checklist
- [X] I have performed a self-review of my code.
- [X] My code follows the style guidelines of this project.
- [X] I have commented my code where necessary.
- [X] I have tested my code locally and verified the website is working as expected.
- [N/A] (if applicable) I have added documentation in the README.
- [N/A] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [N/A] (if applicable) New and existing unit tests pass locally with my changes.
