### PR TITLE
Update newsletter signup link in volunteer template

### DIFF
--- a/templates/volunteer.html
+++ b/templates/volunteer.html
@@ -55,8 +55,7 @@ endblock title %} {% block content %}
       <a
         id="open-popup"
         class="hover-link newsletter pad-lv3 pad-tb0"
-        href="http://eepurl.com/cNFqmj"
-        target="_blank"
+        href="https://techtonica.us13.list-manage.com/subscribe?u=110f637e29d9b2b5f89664fe8&id=22f1ab3b1f"
         rel="noopener noreferrer"
         >sign up for our newsletter</a
       >.


### PR DESCRIPTION
### 📝 Description

- Updated the newsletter signup link in the volunteer template to use a secure HTTPS connection instead of HTTP. This prevents security warnings and ensures a safer browsing experience.

### 🔂 Changes Made
- Updated the Mailchimp newsletter signup link from `http://eepurl.com/cNFqmj` to `https://techtonica.us13.list-manage.com/subscribe?u=110f637e29d9b2b5f89664fe8&id=22f1ab3b1f` in the `volunteer.html` page 
- Removed `target="_blank` to ensure it does not render a blank screen.
- Ensured that the link remains functional and properly redirects users.

### ⚙️ Related Issue
- Issue Number: https://github.com/Techtonica/techtonica.org/issues/665

### 🍏 Type of Change
- Bug fix

### Objective 

- Ensure that users accessing the newsletter signup link are directed to a secure page without any blank pages before a redirect. 

### 🎁 Acceptance Criteria
- [x]  The newsletter link uses HTTPS instead of HTTP. 
- [x] Clicking the link takes users directly to the correct signup page without a blank screen. 

### 🧪 How to test
- Run the website locally.
- Navigate to the volunteers page.
- Ensure that the link pulls up right away. 

### 📸 Screenshots
Before 
<img width="2233" alt="Blank_Screen" src="https://github.com/user-attachments/assets/934878f9-ee6b-4a99-a821-e9de84dca579" />

After
<img width="2227" alt="https" src="https://github.com/user-attachments/assets/2ccc0feb-f7ee-4963-b6de-b06fe405e2e9" />

### ✅ Checklist
- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
