### PR TITLE
Update Application Form Details and Replace Placeholder Text with Finalized Content

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -16,7 +16,8 @@ from flask import Flask, jsonify, redirect, render_template, request, url_for
 from flask_sslify import SSLify
 from pydantic import BaseModel
 from square.client import Client
-
+from course_management import course_bp
+from application_process import application_bp
 from dates import generate_application_timeline
 from db_connection import get_db_connection
 

--- a/templates/app-form-details.html
+++ b/templates/app-form-details.html
@@ -200,9 +200,7 @@ Techtonica Application Details {% endblock title %} {% block content %}
         <li>Assess financial need with Techtonica staff member</li>
         <li>Review official docs and return signed agreement</li>
         <li>
-          Attend Onboarding Day usually about 5 weeks before the official start
-          of the program— pictures, mentor matching, laptop setup, pitch
-          practice, pre-work, etc.
+          Attend Onboarding Day, which typically occurs about five weeks before the program starts.
         </li>
         <li>Join weekly pre-start study groups</li>
         <li>Complete pre-start assignments (about 10-20 hours per week)</li>

--- a/templates/app-form-details.html
+++ b/templates/app-form-details.html
@@ -181,15 +181,14 @@ Techtonica Application Details {% endblock title %} {% block content %}
         </li>
       </ol>
       <h3>Acceptance & Onboarding</h3>
-      <p>
-        Lorem ipsum odor amet, consectetuer adipiscing elit. Et per commodo
-        litora duis neque congue. Convallis quisque suspendisse et est nullam
-        ligula magna habitant conubia. Ad torquent tortor etiam donec; fermentum
-        nascetur malesuada maximus. Amet enim magnis porta nec, donec ac aliquam
-        molestie mollis. Volutpat neque magna malesuada malesuada dolor
-        tristique. Accumsan feugiat varius tortor convallis aenean ridiculus.
-        Dui penatibus gravida sem ipsum hendrerit pulvinar tincidunt efficitur.
-      </p>
+        <ol>
+          <li>Assess financial need with Techtonica staff member </li>
+          <li>Review official docs and return signed agreement</li>
+          <li>Attend Onboarding Day usually about 5 weeks before the official start of the program— pictures, mentor matching, laptop setup, pitch practice, pre-work, etc.</li>
+          <li>Join weekly pre-start study groups</li>
+          <li>Complete pre-start assignments (about 10-20 hours per week)</li>
+          <li>Hit the ground running on day 1, usually in mid-January or mid-July!</li>
+      </ol>
       <button
         type="button"
         class="continue-to-app-btn"

--- a/templates/app-form-details.html
+++ b/templates/app-form-details.html
@@ -40,18 +40,27 @@ Techtonica Application Details {% endblock title %} {% block content %}
         volunteer support per participant.
       </p>
       <h3>Pre-Req and Form Deadline</h3>
+
+      <p><strong>Completion of a JavaScript Pre-Req Course</strong></p>
       <p>
-        Completion of a JavaScript Pre-Req Course Log in to freeCodeCamp and
-        expand the "Legacy JavaScript Algorithms and Data Structures
+        Log in to
+        <a
+          href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/"
+          target="_blank"
+          >freeCodeCamp</a
+        >
+        and expand the "Legacy JavaScript Algorithms and Data Structures
         Certification" section on the /learn page. Complete the first 113
         lessons about Legacy JavaScript. This should take 4-12 hours. Be ready
         to upload a screenshot of the completed course checklist in the
         application form.
       </p>
+
+      <p><strong>Form Deadline</strong></p>
       <p>
         Applications are open twice a year: January to June (H1) and July to
         December (H2). The deadlines for both application forms are at noon
-        Pacific Time—H1 in September and H2 in March.
+        Pacific Time; H1 in September and H2 in March.
       </p>
 
       <h3>Eligibility</h3>

--- a/templates/app-form-details.html
+++ b/templates/app-form-details.html
@@ -30,6 +30,7 @@ Techtonica Application Details {% endblock title %} {% block content %}
         pregnant, face abuse, and more, and if we don't know about it, we can't
         help.
         <br />
+        <br />
         88% of our graduates so far are BIPOC, 21% have a disability, 21% are
         parents, 10% identify outside the gender binary, and 1% are veterans.
         Our cohorts have had between 8 and 18 participants so far, and income
@@ -40,14 +41,19 @@ Techtonica Application Details {% endblock title %} {% block content %}
       </p>
       <h3>Pre-Req and Form Deadline</h3>
       <p>
-        Lorem ipsum odor amet, consectetuer adipiscing elit. Et per commodo
-        litora duis neque congue. Convallis quisque suspendisse et est nullam
-        ligula magna habitant conubia. Ad torquent tortor etiam donec; fermentum
-        nascetur malesuada maximus. Amet enim magnis porta nec, donec ac aliquam
-        molestie mollis. Volutpat neque magna malesuada malesuada dolor
-        tristique. Accumsan feugiat varius tortor convallis aenean ridiculus.
-        Dui penatibus gravida sem ipsum hendrerit pulvinar tincidunt efficitur.
+        Completion of a JavaScript Pre-Req Course Log in to freeCodeCamp and
+        expand the "Legacy JavaScript Algorithms and Data Structures
+        Certification" section on the /learn page. Complete the first 113
+        lessons about Legacy JavaScript. This should take 4-12 hours. Be ready
+        to upload a screenshot of the completed course checklist in the
+        application form.
       </p>
+      <p>
+        Applications are open twice a year: January to June (H1) and July to
+        December (H2). The deadlines for both application forms are at noon
+        Pacific Time—H1 in September and H2 in March.
+      </p>
+
       <h3>Eligibility</h3>
       <p>
         You are eligible to apply for Techtonica’s full-time program if you:
@@ -181,13 +187,19 @@ Techtonica Application Details {% endblock title %} {% block content %}
         </li>
       </ol>
       <h3>Acceptance & Onboarding</h3>
-        <ol>
-          <li>Assess financial need with Techtonica staff member </li>
-          <li>Review official docs and return signed agreement</li>
-          <li>Attend Onboarding Day usually about 5 weeks before the official start of the program— pictures, mentor matching, laptop setup, pitch practice, pre-work, etc.</li>
-          <li>Join weekly pre-start study groups</li>
-          <li>Complete pre-start assignments (about 10-20 hours per week)</li>
-          <li>Hit the ground running on day 1, usually in mid-January or mid-July!</li>
+      <ol>
+        <li>Assess financial need with Techtonica staff member</li>
+        <li>Review official docs and return signed agreement</li>
+        <li>
+          Attend Onboarding Day usually about 5 weeks before the official start
+          of the program— pictures, mentor matching, laptop setup, pitch
+          practice, pre-work, etc.
+        </li>
+        <li>Join weekly pre-start study groups</li>
+        <li>Complete pre-start assignments (about 10-20 hours per week)</li>
+        <li>
+          Hit the ground running on day 1, usually in mid-January or mid-July!
+        </li>
       </ol>
       <button
         type="button"


### PR DESCRIPTION
### 📝 Description

This PR replaces all placeholder text with accurate content, ensuring consistent styling across the application form details. It also updates onboarding/application details in `app-form-details.html` with the latest prerequisites and deadlines.  

### 🔂 Changes Made

- Replaced placeholder text with finalized content.  
- Ensured consistent styling across all text elements.  
- Updated `app-form-details.html` with new onboarding prerequisites and deadlines.

### ⚙️ Related Issue

- Issue Number: https://github.com/Techtonica/techtonica.org/issues/647

### 🍏 Type of Change

- [x] Documentation update


### Objective  

- Ensure that all placeholder text is replaced with finalized content, maintain consistency in styling, and update onboarding/application details to reflect the latest requirements.  

### 🎁 Acceptance Criteria

- [x] Replace all placeholder text with accurate content for the sections.
- [x] Make sure all text on page is accurate with consistent styling
- [x] Submit a PR that merges into the `mvp` branch, not `develop`

### 🧪 How to test

- Run the website locally.
- Navigate to the app-form page.

### 🚀 Deployment Notes (if applicable)

_No new environment variables or system requirements were introduced._  

### 📸 Screenshots (if applicable)

Before 
<img width="1201" alt="Image" src="https://github.com/user-attachments/assets/a74a28ee-d8db-4bb5-a2c3-8f845db6b39f" />
<img width="1201" alt="Image" src="https://github.com/user-attachments/assets/889a6ec7-9c02-45ef-b260-186037cd7b1c" />

After
<img width="2100" alt="Techtonica" src="https://github.com/user-attachments/assets/0debebdc-c768-4d27-83bd-4614d2362737" />

<img width="2100" alt="Application_1" src="https://github.com/user-attachments/assets/ab7170bd-860d-4fd7-a8f3-35e6a99b00d2" />


### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.