### PR TITLE
[Issue 703] Adjust Closed Application Variable Logic

### DIFF
--- a/dates.py
+++ b/dates.py
@@ -129,6 +129,26 @@ def generate_application_timeline():
         cohort_start_day + timedelta(weeks=48) if cohort_start_day else None
     )
 
+    # Define button text based on application status
+    main_text = (
+        f"Apply by {app_close_datetime.strftime('%B %d')} (12pm PT)!"
+        if app_open
+        else "Outsource your software work!"
+    )
+    
+    # Define full-time page button texts
+    fulltime_top_button = (
+        "Apply Now!"
+        if app_open
+        else "Fill out our interest form to be notified about our next cohort!"
+    )
+    
+    fulltime_bottom_button = (
+        f"Apply by {app_close_datetime.strftime('%B %d')} (12pm PT)!"
+        if app_open
+        else "Sign up to join our events"
+    )
+
     return {
         "APP_OPEN_DATE": format_date(app_open_datetime),
         "APP_EXTENDED": app_extended,
@@ -150,9 +170,7 @@ def generate_application_timeline():
         "JOB_SEARCH_START_MONTH_YEAR": format_month_year(training_end),
         "JOB_SEARCH_END_MONTH_YEAR": format_month_year(job_search_end),
         "APP_OPEN": app_open,
-        "TEXT": (
-            "Apply Now!"
-            if not app_open
-            else f"Apply by {app_close_datetime.strftime('%B %d')} (12pm PT)!"
-        ),
+        "TEXT": main_text,
+        "FULLTIME_TOP_BUTTON": fulltime_top_button,
+        "FULLTIME_BOTTOM_BUTTON": fulltime_bottom_button
     }

--- a/templates/full-time-program.html
+++ b/templates/full-time-program.html
@@ -11,25 +11,14 @@ endblock title %} {% block content %}
         adults seeking economic empowerment.
       </p>
       <h2>
-        {% if timeline.APP_OPEN_DATE %}
         <a
-          href="https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform"
+          href="{% if timeline.APP_OPEN %}https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform{% else %}https://docs.google.com/forms/d/e/1FAIpQLSfUdyIAfcU5KSqtYH5J5iPRgu-yycHdebnUKygQLEv-m7oVMw/viewform{% endif %}"
           class="sponsor"
           id="orange-button"
           target="_blank"
           rel="noopener noreferrer"
-          >{{timeline.TEXT}}</a
+          >{{timeline.FULLTIME_TOP_BUTTON}}</a
         >
-        {% else %}
-        <a
-          href="https://docs.google.com/forms/d/e/1FAIpQLSfUdyIAfcU5KSqtYH5J5iPRgu-yycHdebnUKygQLEv-m7oVMw/viewform"
-          class="sponsor"
-          id="orange-button"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Fill out our interest form to be notified about our next cohort!
-        </a>
-        {% endif %}
       </h2>
     </div>
   </div>
@@ -627,28 +616,14 @@ endblock title %} {% block content %}
       </div>
     </div>
     <h2>
-      {% if timeline.APP_OPEN_DATE %}
-      <!-- FT cohort application button that leads to short form when apps are open-->
       <a
-        href="https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform"
+        href="{% if timeline.APP_OPEN %}https://docs.google.com/forms/d/e/1FAIpQLSdk8nJUSuK_xoILyYyf3GIpVypQRtqsx9aQE7odHgX1cWvoHA/viewform{% else %}https://www.eventbrite.com/o/techtonica-11297022451{% endif %}"
         class="sponsor"
         id="orange-button"
         target="_blank"
         rel="noopener noreferrer"
-        >{{timeline.TEXT}}</a
+        >{{timeline.FULLTIME_BOTTOM_BUTTON}}</a
       >
-      {% else %}
-      <!-- event sign up button appears when apps are closed -->
-      <a
-        href="https://www.eventbrite.com/o/techtonica-11297022451"
-        class="sponsor"
-        id="orange-button"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        Sign up to join our events
-      </a>
-      {% endif %}
     </h2>
   </div>
 </div>

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,25 +10,14 @@ endblock title %} {% block content %}
         talent needs.
       </p>
       <h2>
-        {% if timeline.APP_OPEN_DATE %}
         <a
-          href="{{ url_for('render_ft_program_page') }}"
+          href="{% if timeline.APP_OPEN %}{{ url_for('render_ft_program_page') }}{% else %}{{ url_for('render_sponsor_page') }}{% endif %}"
           class="sponsor"
           id="orange-button"
           target="_blank"
           rel="noopener noreferrer"
           >{{ timeline.TEXT }}</a
         >
-        {% else %}
-        <a
-          href="{{ url_for('render_sponsor_page') }}"
-          class="sponsor"
-          id="orange-button"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Outsource your software work!</a
-        >
-        {% endif %}
       </h2>
     </div>
   </div>


### PR DESCRIPTION
### 📝 Description: Context & Changes Made
1. Adjust variable logic so that instead of "Apply Now" text rendering outside of the application open period, the following are the default copy
      - Home page: "Outsource your software work!"
      - FT page: 
          - top button: "Fill out our interest form to be notified about our next cohort!"
          - bottom button: "Sign up to join our events"
2. "Apply by date" only shows during the application period.
3. The full-time page has appropriate default button text when applications are closed. During application period, these buttons will show application-related text.
      - Added `FULLTIME_TOP_BUTTON` that defaults to "Fill out our interest form..." when applications are closed
      - Added `FULLTIME_BOTTOM_BUTTON` that defaults to "Sign up to join our events" when applications are closed
4. Simplified the conditional logic: Instead of having two separate button elements with different text, we now have one button (on the homepage and FT page) that uses `timeline.TEXT`. The URL changes based on `timeline.APP_OPEN`. 

### ⚙️ Related Issue
- Issue Number: #703

### 🍏 Type of Change
- Bug fix
- Refactoring

### 🎁 Acceptance Criteria
1. If applications are open AND a closing date is set:
- All three buttons (both FT page buttons and the homepage button) will show "Apply by date (12pm PT)!"

2. If applications are open BUT no closing date is set:
- All three buttons (both FT page buttons and the homepage button) will show "Apply Now!"

3. If applications are closed (or not set up):
- Top FT page button will show "Fill out our interest form to be notified about our next cohort!"
- Bottom FT page button will show "Sign up to join our events"
- Homepage button will show "Outsource your software work!"

### 🧪 How to test
...incoming...

### 📸 Screenshots (if applicable)
...incoming...