### PR TITLE
Added 3 to setup commands that starts with python.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ pyenv local 3.13.2
 - Ensure correct version of python
 
 ```bash
-python --version
+python3 --version
 # If not 3.13.2, try
 eval "$(pyenv init -)"
 ```
@@ -97,7 +97,7 @@ pip install --upgrade virtualenv
 - Create a virtual environment using venv
 
 ```bash
-python -m venv venv
+python3 -m venv venv
 ```
 
 - Activate your new virtual environment
@@ -119,7 +119,7 @@ pip install --upgrade pip
 ### Install and Upgrade pip-tools
 
 ```bash
-python -m pip install -U pip-tools
+python3 -m pip install -U pip-tools
 ```
 
 ### Install Pre-Commit Hooks


### PR DESCRIPTION
### 📝 Description

Was not able to setup properly and update python version using just `python`. Changed it to `python3`

### 🔂 Changes Made

In the README instructions for setup, it was instructing to use `python --version`. However, the error below is what I would get. To fix it, we would add a 3 and it would work. `python3 --version`

Detail what changes this pull request has and to which areas of the codebase.

I added this change to lines 85, 100 and 122.

### 🍏 Type of Change
- Documentation update

### 📸 Screenshots (if applicable)

Error that I was getting with just `python`
<img width="489" alt="Screenshot 2025-05-15 at 2 35 49 PM" src="https://github.com/user-attachments/assets/8ef9b43c-7279-4c7a-ab18-59f0826dc080" />

Solution with `python3`
<img width="326" alt="Screenshot 2025-05-15 at 2 48 37 PM" src="https://github.com/user-attachments/assets/85cf59b9-3052-4fd9-88da-b78ef635d479" />

### ✅ Checklist

- [ ] I have performed a self-review of my code.
- [ ] My code follows the style guidelines of this project.
- [ ] I have commented my code where necessary.
- [ ] I have tested my code locally and verified the website is working as expected.
- [x] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.
