### PR TITLE
Resolve issue with new tab opening when donating with a card

### DIFF
--- a/templates/donate.html
+++ b/templates/donate.html
@@ -36,7 +36,6 @@ endblock title %} {% block content %}
       href="#"
       onclick="open_window('NjY0ODM=','www.flipcause.com')"
       class="orange-button"
-      target="_blank"
       rel="noopener noreferrer"
     >
       Click here to donate with a card.


### PR DESCRIPTION
### 📝 Description

Resolve issue with new tab opening when donating with a card


### 🔂 Changes Made

Removed the target=blank

### ⚙️ Related Issue

- Issue Number: #765 

### 🍏 Type of Change

- Bug fix

### 🎁 Acceptance Criteria

- Clicking "Click here to donate with a card" does not open a new tab
- Popup to donate with a card appears


### 🧪 How to test

- Navigate to /donate
- Click "Click here to donate with a card" 
- Popup to donate with a card appears and new tab does not open

### 📸 Screenshots (if applicable)

![image](https://github.com/user-attachments/assets/1c165ed4-aff9-4dc0-9136-89a8ab529992)


![image](https://github.com/user-attachments/assets/480b9f3a-b0b5-4bad-bce6-95ec2c7ad734)

### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
- [x] (if applicable) I have added documentation in the README.
- [x] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [x] (if applicable) New and existing unit tests pass locally with my changes.
