### PR TITLE
Part Two Session Day 1 Date Change & Remove TA Role

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -139,12 +139,12 @@ def render_openings_page():
 #     """
 #     return render_template("tapm.html")
 
-@app.route("/openings/ta/")
-def render_ta_page():
-    """
-    Renders the TA page from jinja2 template
-    """
-    return render_template("ta.html")
+# @app.route("/openings/ta/")
+# def render_ta_page():
+#     """
+#     Renders the TA page from jinja2 template
+#     """
+#     return render_template("ta.html")
 
 
 # @app.route("/openings/partnershipsmanager/")

--- a/templates/mentor.html
+++ b/templates/mentor.html
@@ -176,7 +176,7 @@ Mentoring {% endblock title %} {% block content %}
         <td>Mentor applications and open interviews</td>
       </tr>
       <tr>
-        <td>January 14, 2026</td>
+        <td>January 5, 2026</td>
         <td>First day H1 2026 cohort and participant/mentor matches at onboarding day</td>
       </tr>
       <tr>

--- a/templates/openings.html
+++ b/templates/openings.html
@@ -41,9 +41,9 @@ Careers {% endblock title %} {% block content %}
         {# <h3>Technical Associate Program Manager (TAPM)</h3>
         #}
       {# </a> #}
-      <a href="{{ url_for('render_ta_page') }}">
-       <h3>Technical Assistant (TA)</h3>
-      </a>
+      {# <a href="{{ url_for('render_ta_page') }}"> #}
+       {# <h3>Technical Assistant (TA)</h3> #}
+      {# </a> #}
     </p>
     <div>{% include 'contactbutton.html' %}</div>
   </div>


### PR DESCRIPTION
Mentor page has the incorrect day 1 for 2026-H1 part two software applications session. Alternatively, the TA role needs to be taken down

<img width="1300" height="819" alt="Screenshot 2025-09-02 at 3 06 08 PM" src="https://github.com/user-attachments/assets/86388585-1d97-4169-849b-2d63b7c6c24e" />
<img width="1297" height="816" alt="Screenshot 2025-09-02 at 3 05 58 PM" src="https://github.com/user-attachments/assets/35057c1a-1302-4b16-bf3a-037f3b97af24" />
<img width="835" height="188" alt="Screenshot 2025-09-02 at 3 05 51 PM" src="https://github.com/user-attachments/assets/7d49cdd8-27c9-4f0f-8495-40dd03fe3eb8" />
