### PR TITLE
Add css id on hiring partner section

### DIFF
--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -223,6 +223,15 @@ FAQs {% endblock title %} {% block content %}
           <li>Provide weekly pairing with mentors throughout placement</li>
           <li>Pay at least $30/hour</li>
         </ul>
+        <p>
+          <a
+            href="https://techtonica.org/sponsor/#past-hiring-parnters"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            See our past hiring partners.
+          </a>
+        </p>
       </div>
     </div>
 

--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -225,7 +225,7 @@ FAQs {% endblock title %} {% block content %}
         </ul>
         <p>
           <a
-            href="https://techtonica.org/sponsor/#past-hiring-parnters"
+            href="{{ url_for('render_sponsor_page') }}#past-hiring-parnters"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/templates/sponsor.html
+++ b/templates/sponsor.html
@@ -200,7 +200,7 @@ endblock title %} {% block content %}
     <canvas id="myChart"></canvas>
   </div>
   <div class="row row__center">
-    <h1 class="blue-h1 centered">Join our hiring partners!</h1>
+    <h1 class="blue-h1 centered #past-hiring-partners">Join our hiring partners!</h1>
     <div class="row sponsor-container">
       <div class="column centered">
         <a


### PR DESCRIPTION
Add a line that says "See our past hiring partners." link it to a new CSS id on the sponsors page. Recommended ID is "#past-hiring-partners".