### PR TITLE
fix(sponsors): update broken xignite sponsor link

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -35,7 +35,7 @@ endblock title %} {% block content %}
       <p>
         Our program participants are the best of the best! They make it through our rigorous
         application process and program that includes many workshops, interviews,
-        code challenges, pairing sessions, projects, and more. Most 
+        code challenges, pairing sessions, projects, and more. Most
         <a href="{{ url_for('render_sponsor_page') }}">partner companies</a>
         that hire our graduates would like to employ them forever!
       </p>
@@ -99,7 +99,7 @@ endblock title %} {% block content %}
         <h3>Partner Companies</h3>
         <p>
           Companies
-          <a href="{{ url_for('render_sponsor_page') }}"> sponsor</a> the 
+          <a href="{{ url_for('render_sponsor_page') }}"> sponsor</a> the
           program participants' pre-placement training and provide
           mentors.
         </p>
@@ -738,7 +738,7 @@ endblock title %} {% block content %}
           />
         </a>
         <a
-          href="https://www.xignite.org/"
+          href="https://www.quodd.com/"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
### 📝 Description

This pull request resolves a broken hyperlink for the sponsor "Xignite" on the homepage. The sponsor was acquired by Quodd, and their old domain is no longer active. This change updates the link to point to the new, correct website, `quodd.com`. This resolves issue #827.

### 🔂 Changes Made

-   Updated the `href` attribute for the Xignite sponsor logo in `templates/home.html`.
-   The URL was changed from `https://www.xignite.org/` to `https://www.quodd.com/`.

### ⚙️ Related Issue

-   Issue Number: #827

### 🍏 Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Refactoring
-   [ ] Documentation update

### 🎁 Acceptance Criteria

-   The link for the Xignite sponsor logo on the homepage is no longer broken.
-   Clicking the Xignite logo navigates the user to `https://www.quodd.com/`.
-   No other links or page functionality are negatively affected by this change.

### 🧰 New Environment Variables or Requirements

None.

### 🧪 How to test

1.  Run the application locally (e.g., using `docker-compose up`).
2.  Navigate to the homepage in your browser.
3.  Scroll down to the "Thank you for your support!" section.
4.  Locate and click on the Xignite logo.
5.  **Expected Result:** A new tab should open and navigate to `https://www.quodd.com/`.

### 🚀 Deployment Notes (if applicable)

None.

### 📸 Screenshots (if applicable)

N/A - This is a hyperlink change with no visual component.

### ✅ Checklist

-   [x] I have performed a self-review of my code.
-   [x] My code follows the style guidelines of this project.
-   [ ] I have commented my code where necessary.
-   [x] I have tested my code locally and verified the website is working as expected.
-   [ ] (if applicable) I have added documentation in the README.
-   [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
-   [ ] (if applicable) New and existing unit tests pass locally with my changes.