### PR TITLE
fix(testimonials): prevent hamburger menu toggle conflict by removing…

### DIFF
--- a/templates/testimonials.html
+++ b/templates/testimonials.html
@@ -846,5 +846,4 @@ endblock title %} {% block content %}
     </h2>
   </div>
 </div>
-<script type="text/javascript" src="/static/js/scroll.js"></script>
 {% endblock content %}


### PR DESCRIPTION
### 📝 Description

This PR removes a duplicate `scroll.js` script load found on the Testimonials page. The duplicate caused unnecessary re-binding of event listeners and made debugging the mobile hamburger menu issue harder.

While this cleanup improves consistency across pages, it does **not fully resolve** the hamburger menu issue on the Testimonials page, indicating the root cause is likely layout or CSS-related.

Related issue: https://github.com/Techtonica/techtonica.org/issues/866

---

### 🔂 Changes Made

- Removed duplicate `scroll.js` inclusion from `testimonials.html`
- Ensured `scroll.js` is loaded only once via `base.html`

---

### 🍏 Type of Change

- Bug fix  
- Refactoring  

---

### 🧪 How to Test

1. Open the site in a mobile viewport
2. Verify hamburger menu behavior on Home vs Testimonials pages
3. Confirm no console errors related to duplicate scripts
