### PR TITLE
Change link to template link

### DIFF
--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -38,9 +38,9 @@ FAQs {% endblock title %} {% block content %}
         <p>
           We offer underserved, diverse populations an opportunity to be
           involved in a long-term, need-based, sliding-scale, subsidized tuition
-          and stipend scholarships for a software engineering training
-          program that prepares and places them in the software engineering
-          field without having to worry about financial instability. The main
+          and stipend scholarships for a software engineering training program
+          that prepares and places them in the software engineering field
+          without having to worry about financial instability. The main
           differences between us and other programs are:
         </p>
         <ul>
@@ -176,7 +176,7 @@ FAQs {% endblock title %} {% block content %}
       </h3>
       <div class="faq-content">
         <p>
-          See if you're eligible by visiting the 
+          See if you're eligible by visiting the
           <a href="{{ url_for('render_swe_program_page') }}"
             >Part-Time Software Engineering programs page</a
           >
@@ -273,16 +273,14 @@ FAQs {% endblock title %} {% block content %}
 
     <div class="faq-wrapper">
       <h3 id="duration" class="faq-header">
-        <span class="faq-title"
-          >How long is Techtonica's program?</span
-        >
+        <span class="faq-title">How long is Techtonica's program?</span>
         <span class="toggle-icon">
           <span class="toggle-icon-plus">+</span>
           <span class="toggle-icon-minus">-</span>
         </span>
       </h3>
       <div class="faq-content">
-        You can see the length of our program on the 
+        You can see the length of our program on the
         <a href="{{ url_for('render_swe_program_page') }}">
           Part-time Software Engineering program page
         </a>
@@ -405,7 +403,7 @@ FAQs {% endblock title %} {% block content %}
         <p>
           Due to the many layoffs facing software engineers, Techtonica started
           the Seeker Program for Techtonica graduates looking for jobs in 2023.
-          The goal is for each participant (a “Seeker”) to secure a software 
+          The goal is for each participant (a “Seeker”) to secure a software
           engineering job as soon as possible. Seekers work together with some
           structure, accountability, support, reviewing, learning, practice, and
           stipends to make the job search process a little easier.
@@ -613,8 +611,8 @@ FAQs {% endblock title %} {% block content %}
       <div class="faq-content">
         <p>
           Thank you! You can donate once or regularly
-          <a href="https://techtonica.org/donate/">here</a>. Since our fiscal
-          sponsor is
+          <a href="{{ url_for('render_donate_page')}}">here</a>. Since our
+          fiscal sponsor is
           <a href="http://www.socialgoodfund.org">Social Good Fund</a>
           (nonprofit EIN 46-1323531), all donations will be sent to them first
           before being distributed to us. Please
@@ -646,11 +644,7 @@ FAQs {% endblock title %} {% block content %}
             >
             for our full-time program, workshops, or events.
           </li> -->
-          <li>
-            <a onclick="open_window('NjY0ODM=','www.flipcause.com')"
-              >Make donations</a
-            >.
-          </li>
+          <li><a href="{{ url_for('render_donate_page')}}">Donate</a>.</li>
           <li>
             <a
               href="https://docs.google.com/document/d/1Fl9obaF3kdusiEb8dUW8lszzCACRbKSd5GQqwDdFirU/edit"


### PR DESCRIPTION
### 📝 Description

The issue was that the link was hardcoded to point directly to a specific URL unlike other links on the site which are relative template links

### 🔂 Changes Made

Changed the link to a template link.

### ⚙️ Related Issue

- Issue Number: #877

### 🍏 Type of Change

- Bug fix

### 🎁 Acceptance Criteria

- The link is no longer hard-coded but is instead a template link

### 🧪 How to test

Run locally and click the link to see it goes to the local donate page.

### 🚀 Deployment Notes (if applicable)

none

### 📸 Screenshots (if applicable)

No visual changes.

### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
- [ ] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.
