### PR TITLE
[Issue #888] Create a /partner route that redirects to /sponsor

### DIFF
--- a/main_site.py
+++ b/main_site.py
@@ -63,7 +63,7 @@ def render_team_page():
 @app.route("/careers/")
 def render_careers_page():
     """
-    Renders the careers page from jinja2 template
+    Redirects careers route to openings page
     """
     return redirect(url_for("render_openings_page"))
 


### PR DESCRIPTION
### 📝 Description
Create a /partner route that redirects to /sponsor so we know traffic is coming from our ads

### 🔂 Changes Made
- updated careers comment to clarify redirected route
- add new partner route to main file

### ⚙️ Related Issue

- Issue Number: #888

### 🍏 Type of ChangeNew feature

### 🎁 Acceptance Criteria
When `/partner` is typed it redirects user to `/sponsor`

### 📸 Screenshots (if applicable)
![partner route redirect](https://github.com/user-attachments/assets/9c18e111-328a-4cf8-a295-20844d04943f)