### PR TITLE
[Issue 893] update education guideline on swe page

### DIFF
--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -310,8 +310,8 @@ Engineering Program {% endblock title %} {% block content %}
         Techtonica's partners
       </li>
       <li>
-        have not attended a full-time coding bootcamp, completed a C.S. degree,
-        or worked as a software engineer in the last six years
+        have not, in the past six years: attended more than 360 hours of a coding program, pursued or completed a software-engineering-heavy education (for example, a degree in computer science, AI, ML, or data science), or
+worked as a software engineer or in a technical, software engineering-adjacent role (such as data analyst, quantitative analyst, bioinformatician, or QA engineer).
       </li>
       <li>can have high-speed internet set up by the start of the program</li>
       <li>


### PR DESCRIPTION
### 📝 Description
The wording about education guidelines ("have not attended a full-time coding bootcamp, completed a C.S. degree, or worked as a software engineer in the last six years") needs to be adjusted to the following:

"have not, in the past six years: attended more than 360 hours of a coding program, pursued or completed a software-engineering-heavy education (for example, a degree in computer science, AI, ML, or data science), or
worked as a software engineer or in a technical, software engineering-adjacent role (such as data analyst, quantitative analyst, bioinformatician, or QA engineer)."

### ⚙️ Related Issue
Issue Number: #893 

### 🚀 Deployment Considerations 
🌶️ **_Hot Fix Note_** 🌶️: Feature branch was merged into `main` branch via #902 preceding deployment changes. 

### 📸 Screenshots (if applicable)
<img width="1700" height="1001" alt="Education Guideline Update" src="https://github.com/user-attachments/assets/710f7201-34f1-41fe-abd7-91404e5f93fc" />
