### PR TITLE
[🌶️ Hot Fix for Issue #899] SWE, Mentor, & FAQ Page Language Updates for 2026-H2 / 2027-H1 Cohort

### DIFF
--- a/templates/faqs.html
+++ b/templates/faqs.html
@@ -77,8 +77,7 @@ FAQs {% endblock title %} {% block content %}
           </li>
           <li>We provide <strong>MacBooks</strong> to those who need them</li>
           <li>
-            Our program is <strong>six months long</strong> instead of just
-            three​
+            Our training is more than three months: part-time program (<strong>twelve months long</strong>) and full-time program (<strong>six months long</strong>)
           </li>
           <li>
             Our program usually ends with a

--- a/templates/mentor.html
+++ b/templates/mentor.html
@@ -106,9 +106,9 @@ Mentoring {% endblock title %} {% block content %}
             <li>
               Outside of part-time program hours (Monday through Friday from
               5:00PM to 9:00 PM Pacific Time), meet with your mentee or the
-              cohort via video calls at least two hours per week for the year of
-              the program (the six months of the training followed by six months
-              of placement or job search and community support).
+              cohort via video calls at least two hours per week for the duration of
+              the program training followed by six months of placement or job search 
+              and community support.
             </li>
             <li>Respond to mentee communications within 24 hours.</li>
             <li>Submit regular reports to program staff.</li>
@@ -122,7 +122,8 @@ Mentoring {% endblock title %} {% block content %}
           <ul>
             <li>
               Meet with their mentors at least two hours per week for the
-              duration of the training (six months) and placement (six months).
+              duration of program training followed by six months of placement
+              or job searching.
             </li>
             <li>Stay accessible, committed, and engaged with mentors.</li>
             <li>Participate in program assessments.</li>
@@ -143,45 +144,45 @@ Mentoring {% endblock title %} {% block content %}
       </tr>
     </table>
 
-    <h3>September 2025 Web Dev Foundations Cohort Timeline</h3>
+    <h3>September 2026 Web Dev Foundations Cohort Timeline</h3>
     <table class="mentor" cellpadding="0" cellspacing="0">
       <tr>
-        <td>August - September 2025</td>
+        <td>August - September 2026</td>
         <td>Mentor applications and open interviews</td>
       </tr>
       <tr>
-        <td>September 15th - October 10th</td>
+        <td>September 21st - October 16th</td>
         <td>Support participants doing pre-work</td>
       </tr>
       <tr>
-        <td>October 14th</td>
-        <td>First day H2 2025 cohort</td>
+        <td>September 18th</td>
+        <td>First day H2 2026 cohort</td>
       </tr>
       <tr>
-        <td>October 14, 2025 - December 5, 2025</td>
+        <td>September 18, 2026 - December 18, 2026</td>
         <td>Support during foundations Techtonica training</td>
       </tr>
     </table>
 
-    <h3>January 2026 SWE Program Cohort Timeline</h3>
+    <h3>January 2027 SWE Program Cohort Timeline</h3>
     <table class="mentor" cellpadding="0" cellspacing="0">
       <tr>
-        <td>November 2025 - January 2026</td>
+        <td>November 2026 - January 2026</td>
         <td>Mentor applications and open interviews</td>
       </tr>
       <tr>
-        <td>January 5, 2026</td>
+        <td>January 5, 2027</td>
         <td>
-          First day H1 2026 cohort and participant/mentor matches at onboarding
+          First day H1 2027 cohort and participant/mentor matches at onboarding
           day
         </td>
       </tr>
       <tr>
-        <td>January 2026 - June 2026</td>
+        <td>January 2027 - July 2027</td>
         <td>Support during Techtonica training</td>
       </tr>
       <tr>
-        <td>June 2026 - December 2026</td>
+        <td>July 2027 - January 2028</td>
         <td>Support during placement or job search</td>
       </tr>
     </table>

--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -209,8 +209,8 @@ Engineering Program {% endblock title %} {% block content %}
     </p>
     <p>
       Participants are required to use a computer with an Apple operating system
-      or a "Mac" for this program. We recommend a computer that is 2017 or
-      later. Limited laptops are available to rent for this program (we will
+      or a "Mac" for this program. We recommend a computer that is from seven or 
+      fewer years ago. Limited laptops are available to rent for this program (we will
       reach out to accepted applicants to make arrangements).
     </p>
     <p>
@@ -267,8 +267,7 @@ Engineering Program {% endblock title %} {% block content %}
       <li>at the very least graduated from high school or received your GED</li>
       <!-- TO-DO: if application process section name is changes, update this note -->
       <li>
-        completed the JavaScript pre-req (see the Application Process section
-        below)
+        completed four pre-req workshops
       </li>
       <li>can commit to always being present and on time and prepared</li>
       <li>
@@ -431,85 +430,62 @@ Engineering Program {% endblock title %} {% block content %}
   <div class="row">
     <div class="column column-med centered">
       <h3>
-        0. Completion of a JavaScript Algorithms and Data Structures course
+        0. Four Pre-Req Workshops
       </h3>
       <p>
-        Log in to
-        <a
-          href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          freeCodeCamp
-        </a>
-        and expand the "LEGACY JavaScript Algorithms and Data Structures
-        Certification" section on the /learn page. Complete the first 113
-        lessons about Legacy JavaScript. This should take 4-12 hours. Be ready
-        to upload a screenshot of the completed course checklist in the
-        application form.
+        Sign up for and attend four workshops on our
+        <a href="http://techtonica.eventbrite.com/" target="_blank" rel="noopener noreferrer">
+          Eventbrite page
+        </a>.
       </p>
     </div>
     <div class="column column-med centered">
-      <h3>1. Two Application Forms Submitted by September 10th</h3>
+      <h3>1. JavaScript Algorithms and Data Structures Course</h3>
       <p>
-        Thoroughly fill out and submit both the short first application form
-        (this is different from the interest form that is linked on this page
-        before applications are open) and the longer second application form
-        (linked to upon submitting the first form) by the deadline. The second
-        form will take some time, so don't start too late!
+        Log in to freeCodeCamp and expand the
+        <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/" target="_blank" rel="noopener noreferrer">
+          “LEGACY JavaScript Algorithms and 
+          Data Structures Certification”
+        </a>
+        section on the /learn page. Complete the first 113 lessons about Legacy 
+        JavaScript. This should take 4-12 hours. Be ready to upload a screenshot 
+        of the completed course checklist in the application form. 
       </p>
+    </div>
+    <div class="column column-med centered">
+      <h3>2. Part I Application Forms &amp; Acceptance</h3>
+      <p>Thoroughly fill out and submit both the short first application form 
+        (this is different from the interest form that is linked on this page before 
+        applications are open) and the longer second application form (linked to 
+        upon submitting the first form) by the deadline. The second form will take 
+        some time, so don’t start too late!
+      </p>
+      <p>Acceptance emails and signed agreements</p>
     </div>
   </div>
   <div class="row">
     <div class="column column-med centered">
-      <h3>2. Acceptance, Agreements, and Laptops</h3>
-    </div>
-    <div class="column column-med centered">
-      <h3>3. Mandatory Pre-Work & Study Groups</h3>
+      <h3>3. Mandatory Pre-Work &amp; Study Groups</h3>
     </div>
     <div class="column column-med centered">
       <h3>4. Part I: Web Dev Foundations</h3>
     </div>
-  </div>
-  <div class="row">
     <div class="column column-med centered">
-      <h3>5. Pair Programming & Code Challenge</h3>
-    </div>
-    <div class="column column-med centered">
-      <h3>6. Assessment of Technical & Non-Technical Core Competencies</h3>
-    </div>
-    <div class="column column-med centered">
-      <h3>7. Staff Interviews</h3>
-    </div>
-  </div>
-  <div class="row">
-    <div class="column column-med centered">
-      <h3>8. Board Interviews</h3>
+      <h3>5. Application to Part II</h3>
       <p>
-        Participate in board interviews that will include questions about you
-        and your application, and questions from you.
+        Pair Programming &amp; Code Challenges.
+      </p><p> Assessment of Technical &amp; Non-Technical 
+        Core Competencies.</p><p> Staff &amp; Board Interviews. </p><p>Participate in interviews that 
+        will include questions about you and your application, and any questions from you.
       </p>
     </div>
     <div class="column column-med centered">
-      <h3>9. Part II: Software Applications</h3>
+      <h3>6. Part II: Software Applications Program</h3>
     </div>
     <div class="column column-med centered">
-      <h3>10. Placements or Job Search Support</h3>
+      <h3>7. Placements or Job Search Support</h3>
     </div>
   </div>
-  <p>
-    If you are not accepted the first time you apply, you may apply two more
-    times for a maximum of three times, and those do not have to be consecutive
-    application rounds. If you have any special circumstances that make you
-    question your eligibility for Techtonica’s program, please feel free to
-    contact us and we will be happy to discuss with you. If you are interested
-    in Techtonica but cannot participate in the next cohort, please fill out our
-    <a
-      href="https://docs.google.com/forms/d/e/1FAIpQLSfUdyIAfcU5KSqtYH5J5iPRgu-yycHdebnUKygQLEv-m7oVMw/viewform?usp=sf_link"
-      target="_blank"
-      >interest form</a
-    >.
-  </p>
 </div>
 
 <br />

--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -29,7 +29,7 @@ Engineering Program {% endblock title %} {% block content %}
       opportunity to learn technical skills that prepare for a career transition
       into tech in a safe, inclusive space. The Program is made up of two parts:
       the introductory Part I: Web Dev Foundations (September-December) and the
-      advanced Part II: Software Applications (January-June).
+      advanced Part II: Software Applications (January-July).
     </p>
     <p>
       The program takes place Monday through Friday, 5 PM to 9 PM Pacific Time
@@ -53,7 +53,7 @@ Engineering Program {% endblock title %} {% block content %}
           </div>
           <div class="program-card__content">
             <ul class="program-card__features">
-              <li>September-December 2025 (including pre-work)</li>
+              <li>September-December 2026 (including pre-work)</li>
               <li>Up to 30 participants</li>
               <li>Covers the basics of full-stack web development</li>
               <li>Free</li>
@@ -71,7 +71,7 @@ Engineering Program {% endblock title %} {% block content %}
           </div>
           <div class="program-card__content">
             <ul class="program-card__features">
-              <li>January-June 2026</li>
+              <li>January-July 2027</li>
               <li>
                 10-15 participants selected from people who successfully
                 complete Part I
@@ -175,19 +175,19 @@ Engineering Program {% endblock title %} {% block content %}
       >.
     </p>
 
-    <!-- Commenting out past info session video below, to be replaced with 2026 H1 Application Info Session -->
-    <!-- <div class="videowrapper">
+    <!-- Commenting out past info session video below, to be replaced with 2025 H2 Application Info Session -->
+    <div class="videowrapper">
       <iframe
         width="560"
         height="315"
-        src="https://www.youtube.com/embed/Hwnig_yhROM?si=WeivAEXNuDYh48XM"
+        src="https://www.youtube.com/embed/rmj2TUKTk78?si=Ptqhhunll1IMBkMK"
         title="YouTube video player"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
         referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen
       ></iframe>
-    </div> -->
+    </div>
   </div>
   <br />
 
@@ -279,14 +279,14 @@ Engineering Program {% endblock title %} {% block content %}
         a diverse, inclusive, equitable tech environment
       </li>
       <li>
-        have housing that will be stable for the entirety of the six months of
+        have housing that will be stable for the duration of the program
         training and the following six months
       </li>
       <li>
         are willing to live in the U.S. and relocate for an in-person placement
         if required by a placement company (placements we are currently working
-        on for summer 2026 are located in California locations such as Los
-        Angeles, San Diego, and the San Francisco Bay Area)
+        on for the next prospective cohort are located in California locations 
+        such as Los Angeles, San Diego, and the San Francisco Bay Area)
       </li>
       <li>have a U.S. bank account</li>
       <li>
@@ -346,9 +346,9 @@ worked as a software engineer or in a technical, software engineering-adjacent r
     required to live in the San Francisco Bay Area or California to join the
     program, but as stated in the requirements above, you must be willing to
     relocate for an in-person placement if required by a placement company
-    (placements we are currently working on for summer 2026 are located in
-    California locations such as Los Angeles, San Diego, and the San Francisco
-    Bay Area).
+    (placements we are currently working on for the next prospective cohort 
+    are located in California locations such as Los Angeles, San Diego, and 
+    the San Francisco Bay Area).
   </p>
   <h3>What We Look For</h3>
   <div>
@@ -504,7 +504,7 @@ worked as a software engineer or in a technical, software engineering-adjacent r
   <h1 class="main-header__header">Part II: Software Applications Specifics</h1>
   <p>
     Part II: Software Applications will accept 10-15 participants from those who
-    successfully completed Part I and will begin in January 2026.
+    successfully completed Part I and will begin in January 2027.
   </p>
   <p>
     Upon successful completion of Part II of the program, some participants may


### PR DESCRIPTION
### ✏️ Description
- “completed the JavaScript pre-req (see the Application Process section below)” should be changed to “completed four pre-req workshops”
- “We recommend a computer that is 2017 or later.” —> “We recommend a computer that is from seven or fewer years ago.”
- “Schedule Overview” —> The Techtonica Software Engineer Roadmap

**Outstanding:**
- Mentor Page: "six months" of program, dates, and cohort references. 
- FAQ Page: "six month" of program reference

### ⚙️ Related Issue
Issue Number: #899

### 🚀 Deployment Considerations 
🌶️ **_Hot Fix Note_** 🌶️: This work needs to be added to the `main` branch right away from the approved feature branch that was merged into `develop`. Instead of the most recent changes on the `develop` branch, this PR will precede deployment changes to come in. 

### 📸 Screenshots (if applicable)
[GIF of Some Changes](https://www.dropbox.com/scl/fi/sm0b360yd971n1xux3s5j/2026-H2-2027-H1-issue-899-new-cohort-updates.gif?rlkey=c2k03yrla1twekf8yoajdbggr&st=2rkzaks3&dl=0)