### PR TITLE
Update orange button text and link with pre-req language

### DIFF
--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -12,12 +12,12 @@ Engineering Program {% endblock title %} {% block content %}
         non-binary adults seeking economic empowerment through tech careers
       </p>
       <a
-        href="https://docs.google.com/forms/d/e/1FAIpQLSfUdyIAfcU5KSqtYH5J5iPRgu-yycHdebnUKygQLEv-m7oVMw/viewform"
+        href="https://www.eventbrite.com/e/applications-prerequisite-workshops-tickets-1985540956450?aff=oddtdtcreator"
         class="orange-button"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Get notified about the next cohort!
+        Apply through our pre-req workshops
       </a>
     </div>
   </div>
@@ -183,7 +183,15 @@ Engineering Program {% endblock title %} {% block content %}
         src="https://www.youtube.com/embed/rmj2TUKTk78?si=Ptqhhunll1IMBkMK"
         title="YouTube video player"
         frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        allow="
+          accelerometer;
+          autoplay;
+          clipboard-write;
+          encrypted-media;
+          gyroscope;
+          picture-in-picture;
+          web-share;
+        "
         referrerpolicy="strict-origin-when-cross-origin"
         allowfullscreen
       ></iframe>
@@ -209,9 +217,9 @@ Engineering Program {% endblock title %} {% block content %}
     </p>
     <p>
       Participants are required to use a computer with an Apple operating system
-      or a "Mac" for this program. We recommend a computer that is from seven or 
-      fewer years ago. Limited laptops are available to rent for this program (we will
-      reach out to accepted applicants to make arrangements).
+      or a "Mac" for this program. We recommend a computer that is from seven or
+      fewer years ago. Limited laptops are available to rent for this program
+      (we will reach out to accepted applicants to make arrangements).
     </p>
     <p>
       For participants with ADHD, we can provide accommodations and
@@ -266,9 +274,7 @@ Engineering Program {% endblock title %} {% block content %}
       </li>
       <li>at the very least graduated from high school or received your GED</li>
       <!-- TO-DO: if application process section name is changes, update this note -->
-      <li>
-        completed four pre-req workshops
-      </li>
+      <li>completed four pre-req workshops</li>
       <li>can commit to always being present and on time and prepared</li>
       <li>
         are willing to be part of the program during 5pm to 9pm Pacific Time
@@ -285,7 +291,7 @@ Engineering Program {% endblock title %} {% block content %}
       <li>
         are willing to live in the U.S. and relocate for an in-person placement
         if required by a placement company (placements we are currently working
-        on for the next prospective cohort are located in California locations 
+        on for the next prospective cohort are located in California locations
         such as Los Angeles, San Diego, and the San Francisco Bay Area)
       </li>
       <li>have a U.S. bank account</li>
@@ -309,8 +315,12 @@ Engineering Program {% endblock title %} {% block content %}
         Techtonica's partners
       </li>
       <li>
-        have not, in the past six years: attended more than 360 hours of a coding program, pursued or completed a software-engineering-heavy education (for example, a degree in computer science, AI, ML, or data science), or
-worked as a software engineer or in a technical, software engineering-adjacent role (such as data analyst, quantitative analyst, bioinformatician, or QA engineer).
+        have not, in the past six years: attended more than 360 hours of a
+        coding program, pursued or completed a software-engineering-heavy
+        education (for example, a degree in computer science, AI, ML, or data
+        science), or worked as a software engineer or in a technical, software
+        engineering-adjacent role (such as data analyst, quantitative analyst,
+        bioinformatician, or QA engineer).
       </li>
       <li>can have high-speed internet set up by the start of the program</li>
       <li>
@@ -346,9 +356,9 @@ worked as a software engineer or in a technical, software engineering-adjacent r
     required to live in the San Francisco Bay Area or California to join the
     program, but as stated in the requirements above, you must be willing to
     relocate for an in-person placement if required by a placement company
-    (placements we are currently working on for the next prospective cohort 
-    are located in California locations such as Los Angeles, San Diego, and 
-    the San Francisco Bay Area).
+    (placements we are currently working on for the next prospective cohort are
+    located in California locations such as Los Angeles, San Diego, and the San
+    Francisco Bay Area).
   </p>
   <h3>What We Look For</h3>
   <div>
@@ -429,36 +439,42 @@ worked as a software engineer or in a technical, software engineering-adjacent r
   <h1 class="blue-h1">Schedule Overview</h1>
   <div class="row">
     <div class="column column-med centered">
-      <h3>
-        0. Four Pre-Req Workshops
-      </h3>
+      <h3>0. Four Pre-Req Workshops</h3>
       <p>
         Sign up for and attend four workshops on our
-        <a href="http://techtonica.eventbrite.com/" target="_blank" rel="noopener noreferrer">
-          Eventbrite page
-        </a>.
+        <a
+          href="http://techtonica.eventbrite.com/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Eventbrite page </a
+        >.
       </p>
     </div>
     <div class="column column-med centered">
       <h3>1. JavaScript Algorithms and Data Structures Course</h3>
       <p>
         Log in to freeCodeCamp and expand the
-        <a href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/" target="_blank" rel="noopener noreferrer">
-          “LEGACY JavaScript Algorithms and 
-          Data Structures Certification”
+        <a
+          href="https://www.freecodecamp.org/learn/javascript-algorithms-and-data-structures/"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          “LEGACY JavaScript Algorithms and Data Structures Certification”
         </a>
-        section on the /learn page. Complete the first 113 lessons about Legacy 
-        JavaScript. This should take 4-12 hours. Be ready to upload a screenshot 
-        of the completed course checklist in the application form. 
+        section on the /learn page. Complete the first 113 lessons about Legacy
+        JavaScript. This should take 4-12 hours. Be ready to upload a screenshot
+        of the completed course checklist in the application form.
       </p>
     </div>
     <div class="column column-med centered">
       <h3>2. Part I Application Forms &amp; Acceptance</h3>
-      <p>Thoroughly fill out and submit both the short first application form 
-        (this is different from the interest form that is linked on this page before 
-        applications are open) and the longer second application form (linked to 
-        upon submitting the first form) by the deadline. The second form will take 
-        some time, so don’t start too late!
+      <p>
+        Thoroughly fill out and submit both the short first application form
+        (this is different from the interest form that is linked on this page
+        before applications are open) and the longer second application form
+        (linked to upon submitting the first form) by the deadline. The second
+        form will take some time, so don’t start too late!
       </p>
       <p>Acceptance emails and signed agreements</p>
     </div>
@@ -472,11 +488,12 @@ worked as a software engineer or in a technical, software engineering-adjacent r
     </div>
     <div class="column column-med centered">
       <h3>5. Application to Part II</h3>
+      <p>Pair Programming &amp; Code Challenges.</p>
+      <p>Assessment of Technical &amp; Non-Technical Core Competencies.</p>
+      <p>Staff &amp; Board Interviews.</p>
       <p>
-        Pair Programming &amp; Code Challenges.
-      </p><p> Assessment of Technical &amp; Non-Technical 
-        Core Competencies.</p><p> Staff &amp; Board Interviews. </p><p>Participate in interviews that 
-        will include questions about you and your application, and any questions from you.
+        Participate in interviews that will include questions about you and your
+        application, and any questions from you.
       </p>
     </div>
     <div class="column column-med centered">


### PR DESCRIPTION
### 📝 Description

Updated text and link

### 🔂 Changes Made

The orange button now has new text and a link to the Eventbrite signup for the pre-req workshops

### ⚙️ Related Issue

- Issue Number: #913 

### 🍏 Type of Change

- Text and link change

### 🎁 Acceptance Criteria

- Button reads, "Apply through our pre-req workshops"
- Button points to https://www.eventbrite.com/e/applications-prerequisite-workshops-tickets-1985540956450?aff=oddtdtcreator

### 🧰 New Environment Variables or Requirements

n/a

### 🧪 How to test

- Pull changes and run the site.
- Click the link to Apply
- See the update orange button text
- Click the button to go to the Eventbrite signup

### 🚀 Deployment Notes (if applicable)

n/a

### 📸 Screenshots (if applicable)
<img width="410" height="99" alt="Screenshot 2026-04-21 at 4 08 11 PM" src="https://github.com/user-attachments/assets/c1f47591-b7f3-4041-99bc-5167de1165b1" />


Add relevant screenshots to explain visual changes.

### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [ ] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
- [ ] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.
