### PR TITLE
Fix form styling regression using SCSS nesting and placeholder (#928)

### DIFF
--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -1408,20 +1408,30 @@ legend {
   color: #007395cc;
 }
 
-#info-wrapper > fieldset > label {
-  margin-top: 1em;
-  margin-bottom: 0.5em;
-  color: #007395cc;
-}
-
-#info-wrapper > fieldset > input[type="text"],
-#info-wrapper > fieldset > input[type="email"],
-#info-wrapper > fieldset > textarea {
+//here i change > sign by adding a placeholder so that HTML can read it
+%form-field-styles {
   min-width: 90%;
   margin: auto auto 1em auto;
   padding: 0.25em;
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 6px;
+}
+
+//Now I nested the selectors so they adapt cleanly to the new HTML structure
+#info-wrapper {
+  fieldset {
+    label {
+      margin-top: 1em;
+      margin-bottom: 0.5em;
+      color: #007395cc;
+    }
+
+    input[type="text"],
+    input[type="email"],
+    textarea {
+      @extend %form-field-styles;
+    }
+  }
 }
 
 #info-wrapper > fieldset > textarea {


### PR DESCRIPTION
### 📝 Description

This pull request refactors the CSS direct child selectors for form fields inside `style.scss`. The previous structure broke due to a recent Jinja macro refactoring that introduced a new wrapper element, preventing the styles from cascading correctly to input and textarea elements.

### 🔂 Changes Made

- Modified `static/scss/style.scss` (or your local path to style.scss).
- Removed strict direct child selectors (`>`) for `#info-wrapper > fieldset`.
- Implemented native SCSS nesting for `#info-wrapper` and its nested `fieldset`, `label`, `input`, and `textarea` elements.
- Created and extended a `%form-field-styles` placeholder to cleanly handle repetitive input styling and reduce duplication as requested.

### ⚙️ Related Issue

- Issue Number: #928

### 🍏 Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation update

### 🎁 Acceptance Criteria

- [x] Form input fields and textareas style correctly even when wrapped inside Jinja-generated `div.form-row` containers.
- [x] Replaced rigid direct child selectors with clean, nested SCSS rules.
- [x] Avoided code duplication by utilizing an SCSS placeholder (`%form-field-styles`).

### 🧰 New Environment Variables or Requirements

None.

### 🧪 How to test

1. Open the website locally.
2. Navigate to any form that utilizes the updated Jinja macros (such as the "Post a Job" form).
3. Verify that the input boxes, text fields, and textareas successfully render with a `min-width: 90%`, rounded borders, and correct padding instead of appearing unstyled.

### 🚀 Deployment Notes (if applicable)

N/A

### 📸 Screenshots (if applicable)

N/A

### ✅ Checklist

- [x] I have performed a self-review of my code.
- [x] My code follows the style guidelines of this project.
- [x] I have commented my code where necessary.
- [x] I have tested my code locally and verified the website is working as expected.
- [ ] (if applicable) I have added documentation in the README.
- [ ] (if applicable) I have added tests that prove my fix is effective or that my feature works.
- [ ] (if applicable) New and existing unit tests pass locally with my changes.