### PR TITLE
Add Sept 2026 Part Time Info Session Video to SWE Page

### DIFF
--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -180,7 +180,7 @@ Engineering Program {% endblock title %} {% block content %}
       <iframe
         width="560"
         height="315"
-        src="https://www.youtube.com/embed/rmj2TUKTk78?si=Ptqhhunll1IMBkMK"
+        src="https://www.youtube.com/embed/l4w1lhZ8Emk?si=zskbUoqHWt64BpMw"
         title="YouTube video player"
         frameborder="0"
         allow="


### PR DESCRIPTION
### 📝 Description
This replaces the previous info session video with the September 2026 5pm Info Session Video from YouTube

<img width="1516" height="913" alt="Screenshot 2026-06-12 at 7 56 10 PM" src="https://github.com/user-attachments/assets/993e6d1d-8ee2-441e-af8b-3ec9a6be75dc" />
