### PR TITLE
Change SWE page CTA link: eventbrite prereq => interest form

### DIFF
--- a/templates/software-engineering-program.html
+++ b/templates/software-engineering-program.html
@@ -12,12 +12,12 @@ Engineering Program {% endblock title %} {% block content %}
         non-binary adults seeking economic empowerment through tech careers
       </p>
       <a
-        href="https://www.eventbrite.com/e/applications-prerequisite-workshops-tickets-1985540956450?aff=oddtdtcreator"
+        href="https://docs.google.com/forms/d/e/1FAIpQLSfUdyIAfcU5KSqtYH5J5iPRgu-yycHdebnUKygQLEv-m7oVMw/viewform"
         class="orange-button"
         target="_blank"
         rel="noopener noreferrer"
       >
-        Apply through our pre-req workshops
+        Get notified about the next cohort!
       </a>
     </div>
   </div>


### PR DESCRIPTION
The following changes the eventbrite link on the SWE page to the interest form link
<img width="1421" height="942" alt="Screenshot 2026-08-18 at 1 58 49 PM" src="https://github.com/user-attachments/assets/520e6293-3c86-4a78-ba21-b4beb09d00bf" />
